### PR TITLE
add talks content and individual talk pages

### DIFF
--- a/content/talks/evolution-of-an-api.md
+++ b/content/talks/evolution-of-an-api.md
@@ -1,0 +1,45 @@
+---
+title: 'Evolution of an API: A Case for GraphQL'
+date: '2019-09-20'
+category: 'graphql'
+description: 'Looking at the history of best practices for API development and the timeline that got us to where we are today.'
+presentedAt:
+  - eventDate: '2019-09-20'
+    eventName: 'UtahJS'
+    eventType: 'conference'
+    eventUrl: 'https://conf.utahjs.com/'
+    location: 'Salt Lake City, UT'
+---
+
+APIs have evolved significantly over the decades. This talk traces that evolution and makes the case for why GraphQL represents the next step forward.
+
+## A Brief History
+
+### RPC (1980s-1990s)
+Remote Procedure Calls - tightly coupled, language-specific protocols.
+
+### SOAP (Late 1990s-2000s)
+XML-based, verbose, but introduced standards for web services.
+
+### REST (2000s-Present)
+Resource-oriented, HTTP-native, simpler than SOAP but with its own challenges:
+- Over-fetching and under-fetching
+- Multiple round trips for related data
+- Versioning headaches
+
+### GraphQL (2015-Present)
+- Client specifies exactly what data it needs
+- Single endpoint, single request
+- Strongly typed schema
+- Introspection built-in
+
+## Why GraphQL Now?
+
+The shift to mobile and the proliferation of client types made REST's limitations more apparent:
+- Mobile apps need minimal data transfer
+- Different clients need different data shapes
+- Real-time requirements are increasing
+
+## Getting Started
+
+The talk concludes with practical advice for adopting GraphQL incrementally alongside existing REST APIs.

--- a/content/talks/machine-learning-with-javascript.md
+++ b/content/talks/machine-learning-with-javascript.md
@@ -1,0 +1,48 @@
+---
+title: 'Teaching Machines How to Do Cool Things with JavaScript'
+date: '2018-04-28'
+category: 'ai'
+description: 'A closer look at modern applications of machine learning, and the how and why of JavaScript implementation.'
+presentedAt:
+  - eventDate: '2018-04-28'
+    eventName: 'Zeit Day'
+    eventType: 'conference'
+    eventUrl: 'https://zeit.co/day'
+    recordedPresentationUrl: 'https://youtu.be/QaV7a64mUYE'
+    location: 'San Francisco, CA'
+---
+
+My first conference talk! Presented at Zeit Day 2018, this talk explores why JavaScript is a legitimate choice for machine learning and demonstrates practical applications.
+
+## Why JavaScript for ML?
+
+- **Ubiquity** - JavaScript runs everywhere (browser, server, edge)
+- **Accessibility** - Lower barrier to entry for web developers
+- **Real-time** - Run models in the browser without server round-trips
+- **Privacy** - User data never leaves the device
+
+## The ML Landscape in 2018
+
+At the time of this talk, the JavaScript ML ecosystem was emerging:
+- TensorFlow.js had just been released
+- Brain.js was gaining traction
+- ML5.js was making ML accessible to creative coders
+
+## Demo: Image Classification in the Browser
+
+The talk includes a live demo of running image classification entirely in the browser:
+1. Load a pre-trained MobileNet model
+2. Capture webcam input
+3. Classify images in real-time
+4. Display predictions with confidence scores
+
+## Key Takeaways
+
+- You don't need Python to do ML
+- Pre-trained models make it easy to get started
+- Browser-based ML enables new user experiences
+- The ecosystem is growing rapidly
+
+## Looking Back
+
+This talk from 2018 feels prescient given where we are now with AI. The fundamentals of running models in JavaScript have only become more relevant with the rise of edge computing and on-device AI.

--- a/content/talks/mcp-beyond-task-execution.md
+++ b/content/talks/mcp-beyond-task-execution.md
@@ -1,0 +1,53 @@
+---
+title: 'MCP: Going Beyond Task Execution'
+date: '2025-05-14'
+category: 'ai'
+description: 'Embracing agentic workflows as the next iteration of the MCP client-server model.'
+presentedAt:
+  - eventDate: '2025-05-14'
+    eventName: 'MCP Night'
+    eventType: 'meetup'
+    eventUrl: 'https://lu.ma/quvg7kzs?tk=hC0BvS'
+    location: 'San Francisco, CA'
+blogPost: 'mcp-beyond-task-execution'
+---
+
+Anthropic's [Model Context Protocol](https://modelcontextprotocol.io/) is having a moment. Launched in October 2024, it introduces a standard protocol for enabling LLMs to do more things on the internet.
+
+## The MCP Model
+
+The protocol introduces the concept of an MCP host, client, and server:
+
+![The MCP host, client, and model](/images/mcp_model.png)
+
+- **MCP host** - the session provider, containing the context and LLM connections on behalf of the agent system
+- **MCP client** - created by the host, substantiates a connection to the MCP servers
+- **MCP server** - provides access to a tool or collection of tools
+
+Think of the MCP server as a set of toddler-friendly keys we provide the model. Instead of expecting the LLM to know how to navigate every publicly-available API, we're providing a framework with clear boundaries and capability.
+
+## Remote Servers Changed Things
+
+Until around April 2025, MCP servers were primarily focused on locally-enabled functionality. Then remote MCP servers hit - hosted, already-on servers that enable standard functionality.
+
+On May 1, 2025, we at Cloudflare [launched thirteen new public, remote MCP servers](https://blog.cloudflare.com/thirteen-new-mcp-servers-from-cloudflare) for developer use.
+
+## The Problem: Task Execution
+
+A lot of "agentic" implementations I've seen rely on a near 1:1 mapping of server-client functionality. I call this model "task execution" - the next generation of API calls.
+
+![Task execution model: One MCP server to one MCP client](/images/mcp_tasks.png)
+
+Frankly, MCP servers are just an expensive `curl` when used this way.
+
+## What True Agentic Workflows Look Like
+
+We need client applications that support agent-to-agent orchestration. One MCP client can map to many MCP servers, creating a true "agent" capable of many functions.
+
+![Agentic model: One MCP client can map to many MCP servers](/images/mcp_host_client_server_agent.png)
+
+## Resources
+
+- [Agents SDK](https://github.com/cloudflare/agents)
+- [Cloudflare AI Playground](https://playground.ai.cloudflare.com)
+- [Guide: Build a Remote MCP server](https://developers.cloudflare.com/agents/guides/remote-mcp-server/)

--- a/content/talks/ml-on-the-cl.md
+++ b/content/talks/ml-on-the-cl.md
@@ -1,0 +1,58 @@
+---
+title: 'ML on the CL'
+date: '2018-06-28'
+category: 'ai'
+description: 'Implementing machine learning on the command line using Node.js libraries. Quick-start projects you can get started with on your own.'
+presentedAt:
+  - eventDate: '2018-06-28'
+    eventName: 'js.la'
+    eventType: 'meetup'
+    eventUrl: 'https://js.la'
+    recordedPresentationUrl: 'https://youtu.be/MzrDy4s8MF8'
+    location: 'Los Angeles, CA'
+---
+
+Machine learning doesn't have to mean Python and Jupyter notebooks. This talk explores how to build ML-powered CLI tools using Node.js.
+
+## Why CLI?
+
+- **Scriptable** - Integrate into existing workflows
+- **Fast iteration** - No UI to build
+- **Composable** - Unix philosophy, pipe data between tools
+- **Accessible** - Every developer has a terminal
+
+## Tools and Libraries
+
+### TensorFlow.js
+Run TensorFlow models in Node.js:
+```javascript
+const tf = require('@tensorflow/tfjs-node')
+const model = await tf.loadLayersModel('file://./model/model.json')
+```
+
+### Natural
+NLP toolkit for Node:
+```javascript
+const natural = require('natural')
+const tokenizer = new natural.WordTokenizer()
+tokenizer.tokenize("This is a sentence")
+```
+
+### Brain.js
+Simple neural networks:
+```javascript
+const brain = require('brain.js')
+const net = new brain.NeuralNetwork()
+net.train([{ input: [0, 0], output: [0] }])
+```
+
+## Demo Projects
+
+The talk walks through building:
+1. A sentiment analysis CLI
+2. A text classifier for categorizing input
+3. An image recognition tool using pre-trained models
+
+## Getting Started
+
+All demo code is available on GitHub with step-by-step instructions.

--- a/content/talks/performant-ab-testing.md
+++ b/content/talks/performant-ab-testing.md
@@ -1,0 +1,46 @@
+---
+title: 'Performant Experimentation at Scale'
+date: '2023-10-22'
+category: 'nextjs'
+description: 'Developing data-driven experiments without introducing layout shift, using Next.js and Edge Middleware.'
+presentedAt:
+  - eventDate: '2023-10-22'
+    eventName: 'Next.js Conf'
+    eventType: 'conference'
+    eventUrl: 'https://nextjs.org/conf'
+    recordedPresentationUrl: 'https://www.youtube.com/watch?v=c_wYt7ur2yc'
+    location: 'San Francisco, CA'
+---
+
+A/B testing is essential for data-driven product decisions, but traditional implementations often introduce layout shift and degrade user experience. This talk explores how to build performant experimentation infrastructure using Next.js Edge Middleware.
+
+## The Problem with Traditional A/B Testing
+
+Most A/B testing solutions work by:
+1. Loading the page
+2. Making a client-side request to determine the variant
+3. Swapping content after the page has rendered
+
+This causes visible layout shift and poor Core Web Vitals scores.
+
+## Edge Middleware to the Rescue
+
+With Next.js Edge Middleware, we can make variant decisions at the edge before the page even starts rendering:
+
+1. Request hits the edge
+2. Middleware determines variant based on cookie or random assignment
+3. Response is personalized before reaching the client
+4. Zero layout shift
+
+## Key Techniques
+
+- **Cookie-based persistence** - Users see consistent variants across sessions
+- **Edge-side variant selection** - Decisions happen in milliseconds at the edge
+- **Streaming-compatible** - Works with React Server Components and streaming
+
+## Results at Vercel
+
+We used this approach to run experiments across vercel.com, achieving:
+- Zero layout shift from experiments
+- Sub-millisecond variant assignment
+- Statistically significant results faster due to better user experience

--- a/content/talks/react-to-react-native.md
+++ b/content/talks/react-to-react-native.md
@@ -1,0 +1,52 @@
+---
+title: 'React to React Native: How Hard Could It Be?'
+date: '2019-11-15'
+category: 'react'
+description: "If I already know React, how hard could it be to learn React Native? This talk answers that question and helps you decide if you need a native app at all."
+presentedAt:
+  - eventDate: '2019-11-15'
+    eventName: 'RVA.js'
+    eventType: 'conference'
+    location: 'Richmond, VA'
+  - eventDate: '2019-05-28'
+    eventName: 'DenverScript'
+    eventType: 'meetup'
+    eventUrl: 'https://www.code-talent.com/event-calendar/2019/5/28/denver-script'
+    location: 'Denver, CO'
+---
+
+"If I already know React, how hard could it be to learn React Native?" is a question I've heard a lot as a React consultant. This talk aims to answer it honestly.
+
+## What Transfers
+
+The good news - a lot transfers:
+- Component model and JSX
+- State management (useState, useReducer, Redux, etc.)
+- Hooks and lifecycle concepts
+- Most of your JavaScript/TypeScript knowledge
+
+## What's Different
+
+The challenging parts:
+- **No DOM** - div, span, p become View, Text
+- **Styling** - Flexbox by default, no CSS cascade
+- **Navigation** - React Navigation vs React Router
+- **Platform differences** - iOS and Android have different conventions
+- **Native modules** - Sometimes you need to bridge to native code
+
+## Do You Even Need Native?
+
+Before diving into React Native, consider:
+- **PWA** - Progressive Web Apps cover many use cases
+- **Capacitor/Ionic** - Web views with native capabilities
+- **Expo** - Managed React Native without native code
+
+## The Verdict
+
+React Native is learnable for React developers, but it's not "just React." Budget time for:
+- Learning the component primitives
+- Understanding the build/deploy pipeline
+- Platform-specific debugging
+- Performance optimization (it's different from web)
+
+The talk includes demos of common gotchas and how to solve them.

--- a/content/talks/ts-in-react.md
+++ b/content/talks/ts-in-react.md
@@ -1,0 +1,67 @@
+---
+title: 'TypeScript + React: A Love Story'
+date: '2019-04-16'
+category: 'typescript'
+description: 'How TypeScript made me a better JavaScript developer, and best practices for using TypeScript with React.'
+presentedAt:
+  - eventDate: '2019-04-16'
+    eventName: 'React Denver'
+    eventType: 'meetup'
+    eventUrl: 'https://www.meetup.com/ReactDenver/events/kgrmmqyzgbvb/'
+    recordedPresentationUrl: 'https://youtu.be/iBlGIS-UQsw?t=1638'
+    location: 'Denver, CO'
+  - eventDate: '2018-10-25'
+    eventName: 'Formidable Denver Open House'
+    eventType: 'meetup'
+    eventUrl: 'https://formidable-denver.eventbrite.com'
+    location: 'Denver, CO'
+---
+
+TypeScript and React are a perfect match. This talk explores why, and shares practical patterns for getting the most out of both.
+
+## Why TypeScript?
+
+- **Catch errors at compile time** - Not in production
+- **Better IDE support** - Autocomplete, refactoring, go-to-definition
+- **Self-documenting code** - Types are documentation that can't go stale
+- **Confidence in refactoring** - Change code without fear
+
+## TypeScript + React Patterns
+
+### Typing Props
+
+```typescript
+interface ButtonProps {
+  label: string
+  onClick: () => void
+  variant?: 'primary' | 'secondary'
+}
+
+function Button({ label, onClick, variant = 'primary' }: ButtonProps) {
+  return <button className={variant} onClick={onClick}>{label}</button>
+}
+```
+
+### Typing Hooks
+
+```typescript
+const [count, setCount] = useState<number>(0)
+const inputRef = useRef<HTMLInputElement>(null)
+```
+
+### Generic Components
+
+```typescript
+interface ListProps<T> {
+  items: T[]
+  renderItem: (item: T) => React.ReactNode
+}
+
+function List<T>({ items, renderItem }: ListProps<T>) {
+  return <ul>{items.map(renderItem)}</ul>
+}
+```
+
+## The Journey
+
+The talk shares my personal journey from JavaScript skeptic to TypeScript advocate, and the "aha moments" along the way.

--- a/content/talks/urql-devtools.md
+++ b/content/talks/urql-devtools.md
@@ -1,0 +1,46 @@
+---
+title: 'Demystifying urql Using the Dev Tools'
+date: '2020-07-16'
+category: 'graphql'
+description: 'Taking a closer look at the urql browser dev tools and using them to better understand urql as a GraphQL client.'
+presentedAt:
+  - eventDate: '2020-05-26'
+    eventName: 'GraphQL Denver'
+    eventType: 'meetup'
+    eventUrl: 'https://www.meetup.com/GraphQLDenver/events/267717269/'
+    location: 'virtual'
+  - eventDate: '2020-07-16'
+    eventName: 'RESTLess London'
+    eventType: 'meetup'
+    location: 'virtual'
+---
+
+urql is a highly customizable and versatile GraphQL client. This talk explores how to use the urql dev tools to better understand what's happening under the hood.
+
+## Why urql?
+
+urql offers a balance between simplicity and power:
+- Smaller bundle size than Apollo Client
+- Highly extensible exchange system
+- First-class React hooks support
+- Normalized caching (optional)
+
+## The Dev Tools
+
+The urql dev tools browser extension gives you visibility into:
+- **Operations** - See every query, mutation, and subscription
+- **Cache** - Inspect the normalized cache state
+- **Exchanges** - Understand how data flows through the exchange pipeline
+- **Timeline** - Debug the sequence of events
+
+## Key Insights
+
+Using the dev tools, you can:
+1. Debug why a query isn't updating
+2. Understand cache invalidation
+3. Optimize your exchange pipeline
+4. Identify unnecessary network requests
+
+## Demo
+
+The talk includes a live demo walking through common debugging scenarios using the dev tools.

--- a/scripts/build-static.mjs
+++ b/scripts/build-static.mjs
@@ -4,6 +4,7 @@ import matter from 'gray-matter'
 import { fileURLToPath } from 'url'
 import { WritingPage } from '../src/pages/WritingPage.js'
 import { SpeakingPage } from '../src/pages/SpeakingPage.js'
+import { TalkPage } from '../src/pages/TalkPage.js'
 import { AboutPage } from '../src/pages/AboutPage.js'
 import { BlogPostPage } from '../src/pages/BlogPostPage.js'
 import { NotFoundPage } from '../src/pages/NotFoundPage.js'
@@ -14,9 +15,8 @@ import { generateOgImages } from './generate-og-images.mjs'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
 const CONTENT_DIR = path.join(ROOT, 'content')
+const TALKS_DIR = path.join(CONTENT_DIR, 'talks')
 const OUT_DIR = path.join(ROOT, 'static')
-
-const TALK_DATA_URL = 'https://raw.githubusercontent.com/kale-stew/all-talks/main/content/talks.json'
 
 function copyDir(src, dest) {
   if (!fs.existsSync(src)) return
@@ -81,13 +81,32 @@ async function main() {
     writeHtml(`writing/${post.id}/index.html`, BlogPostPage({ post }))
   }
 
-  // Speaking - fetch from GitHub
-  try {
-    const resp = await fetch(TALK_DATA_URL)
-    const talks = await resp.json()
-    writeHtml('speaking/index.html', SpeakingPage({ talks }))
-  } catch {
-    console.log('  warning: could not fetch talk data, skipping speaking page')
+  // Speaking - read talks from content/talks/
+  const talks = []
+  if (fs.existsSync(TALKS_DIR)) {
+    const talkFiles = fs.readdirSync(TALKS_DIR).filter((f) => f.endsWith('.md'))
+    for (const fileName of talkFiles) {
+      const fileContents = fs.readFileSync(path.join(TALKS_DIR, fileName), 'utf8')
+      const { data, content } = matter(fileContents)
+      talks.push({
+        id: fileName.replace(/\.md$/, ''),
+        title: data.title || fileName.replace(/\.md$/, ''),
+        description: data.description || null,
+        category: data.category || 'general',
+        date: data.date || '',
+        presentedAt: data.presentedAt || [],
+        blogPost: data.blogPost || null,
+        content,
+      })
+    }
+    talks.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  }
+
+  writeHtml('speaking/index.html', SpeakingPage({ talks }))
+
+  // Individual talk pages
+  for (const talk of talks) {
+    writeHtml(`speaking/${talk.id}/index.html`, TalkPage({ talk }))
   }
 
   // Projects

--- a/scripts/seed-db.mjs
+++ b/scripts/seed-db.mjs
@@ -1,13 +1,15 @@
-import { readFileSync, readdirSync } from 'fs'
+import { readFileSync, readdirSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import matter from 'gray-matter'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const contentDir = join(__dirname, '..', 'content')
-const files = readdirSync(contentDir).filter(f => f.endsWith('.md'))
+const talksDir = join(contentDir, 'talks')
 
-const posts = files.map((f) => {
+// Read blog posts
+const blogFiles = readdirSync(contentDir).filter(f => f.endsWith('.md'))
+const posts = blogFiles.map((f) => {
   const raw = readFileSync(join(contentDir, f), 'utf-8')
   const { data } = matter(raw)
   const id = f.replace(/\.md$/, '')
@@ -22,11 +24,36 @@ const posts = files.map((f) => {
   }
 })
 
+// Read talks
+const talks = []
+if (existsSync(talksDir)) {
+  const talkFiles = readdirSync(talksDir).filter(f => f.endsWith('.md'))
+  for (const f of talkFiles) {
+    const raw = readFileSync(join(talksDir, f), 'utf-8')
+    const { data } = matter(raw)
+    const id = f.replace(/\.md$/, '')
+    talks.push({
+      id,
+      title: data.title,
+      description: data.description ?? null,
+      category: data.category ?? 'general',
+      date: data.date ?? new Date().toISOString().split('T')[0],
+      type: 'talk',
+      tags: null,
+    })
+  }
+}
+
 // Generate SQL insert statements
-const inserts = posts.map((p) => {
-  const esc = (s) => (s ?? '').replace(/'/g, "''")
+const esc = (s) => (s ?? '').replace(/'/g, "''")
+
+const blogInserts = posts.map((p) => {
   return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags) VALUES ('${esc(p.id)}', '${esc(p.title)}', '${esc(p.description)}', '${esc(p.category)}', '${esc(p.date)}', 'blog', NULL);`
 })
 
-console.log(inserts.join('\n'))
-console.error(`Generated ${inserts.length} INSERT statements`)
+const talkInserts = talks.map((t) => {
+  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags) VALUES ('${esc(t.id)}', '${esc(t.title)}', '${esc(t.description)}', '${esc(t.category)}', '${esc(t.date)}', 'talk', NULL);`
+})
+
+console.log([...blogInserts, ...talkInserts].join('\n'))
+console.error(`Generated ${blogInserts.length} blog posts and ${talkInserts.length} talks`)

--- a/src/pages/SpeakingPage.tsx
+++ b/src/pages/SpeakingPage.tsx
@@ -1,8 +1,20 @@
 import { html } from 'hono/html'
 import { Layout, Nav, Footer } from '../components/Layout'
-import type { TalkItem } from '../content'
 
-export function SpeakingPage({ talks }: { talks: TalkItem[] }) {
+export interface TalkListItem {
+  id: string
+  title: string
+  description: string | null
+  category: string
+  date: string
+  presentedAt: {
+    eventName: string
+    eventType: 'meetup' | 'conference'
+    location: string
+  }[]
+}
+
+export function SpeakingPage({ talks }: { talks: TalkListItem[] }) {
   return Layout({
     title: 'Speaking',
     description: 'Conference talks and presentations by Kylie Czajkowski.',
@@ -17,11 +29,14 @@ export function SpeakingPage({ talks }: { talks: TalkItem[] }) {
           <div class="card-grid">
             ${talks.map((talk) => html`
               <article class="card">
-                <h3>${talk.title}</h3>
+                <h3><a href="/speaking/${talk.id}">${talk.title}</a></h3>
                 <p>${talk.description}</p>
                 <div class="meta">
                   <span class="tag">${talk.category}</span>
-                  ${talk.date}
+                  ${talk.presentedAt.length > 0
+                    ? html`<span class="text-muted">${talk.presentedAt[0].eventName}</span>`
+                    : talk.date
+                  }
                 </div>
               </article>
             `)}

--- a/src/pages/TalkPage.tsx
+++ b/src/pages/TalkPage.tsx
@@ -1,0 +1,86 @@
+import { html } from 'hono/html'
+import { Layout, Nav, Footer } from '../components/Layout'
+import { marked } from 'marked'
+
+export interface TalkPost {
+  id: string
+  title: string
+  description: string | null
+  category: string
+  date: string
+  content: string
+  presentedAt: {
+    eventDate: string
+    eventName: string
+    eventType: 'meetup' | 'conference'
+    eventUrl?: string
+    recordedPresentationUrl?: string
+    location: string
+  }[]
+  blogPost?: string
+}
+
+export function TalkPage({ talk }: { talk: TalkPost }) {
+  const htmlContent = marked.parse(talk.content, { async: false }) as string
+
+  return Layout({
+    title: talk.title,
+    description: talk.description ?? '',
+    content: html`
+      ${Nav()}
+      <main>
+        <div class="container">
+          <div class="content">
+            <article class="prose">
+              <header class="page-title">
+                <h1>${talk.title}</h1>
+                <p>
+                  <span class="tag">${talk.category}</span>
+                  ${talk.date}
+                </p>
+              </header>
+
+              <div class="talk-presentations">
+                <h3>Presented at</h3>
+                <ul class="presentation-list">
+                  ${talk.presentedAt.map((p) => html`
+                    <li>
+                      <strong>
+                        ${p.eventUrl
+                          ? html`<a href="${p.eventUrl}" target="_blank" rel="noopener">${p.eventName}</a>`
+                          : p.eventName
+                        }
+                      </strong>
+                      <span class="tag">${p.eventType}</span>
+                      <br />
+                      <span class="text-muted">${p.location} · ${p.eventDate}</span>
+                      ${p.recordedPresentationUrl ? html`
+                        <br />
+                        <a href="${p.recordedPresentationUrl}" target="_blank" rel="noopener" class="link-accent">Watch recording</a>
+                      ` : ''}
+                    </li>
+                  `)}
+                </ul>
+              </div>
+
+              ${talk.blogPost ? html`
+                <p class="text-muted">
+                  Related blog post: <a href="/writing/${talk.blogPost}" class="link-accent">${talk.title}</a>
+                </p>
+              ` : ''}
+
+              <hr class="divider" />
+
+              ${html([htmlContent])}
+            </article>
+            <hr class="divider" />
+            <p class="text-center">
+              <a href="/speaking" class="link-accent">← Back to Speaking</a>
+            </p>
+          </div>
+        </div>
+      </main>
+      ${Footer()}
+    `,
+  })
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -444,6 +444,40 @@ footer {
   height: 24px;
 }
 
+/* === Talk Presentations === */
+.talk-presentations {
+  background: var(--color-bg-card);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  margin-bottom: var(--space-xl);
+  border: 1px solid var(--color-accent-light);
+}
+
+.talk-presentations h3 {
+  margin-top: 0;
+  margin-bottom: var(--space-md);
+}
+
+.presentation-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.presentation-list li {
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--color-accent-light);
+}
+
+.presentation-list li:last-child {
+  border-bottom: none;
+}
+
+.presentation-list .tag {
+  margin-left: var(--space-sm);
+  font-size: 0.7rem;
+}
+
 /* === Divider === */
 .divider {
   border: none;


### PR DESCRIPTION
- migrate talks from kale-stew/all-talks to content/talks/
- add TalkPage component for individual talk pages
- update SpeakingPage to link to talk details
- update build script to generate /speaking/[slug] pages
- update seed-db to include talks in d1 database
- add presentation list styling