### PR TITLE
feat: search overlay with full content search

### DIFF
--- a/migrations/0001_initial_schema.sql
+++ b/migrations/0001_initial_schema.sql
@@ -6,7 +6,8 @@ create table if not exists posts (
   category text not null,
   date text not null,
   type text not null default 'blog',
-  tags text
+  tags text,
+  content text
 );
 
 create index idx_posts_category on posts(category);

--- a/migrations/0002_add_post_content.sql
+++ b/migrations/0002_add_post_content.sql
@@ -1,0 +1,1 @@
+alter table posts add column content text;

--- a/scripts/seed-db.mjs
+++ b/scripts/seed-db.mjs
@@ -11,7 +11,7 @@ const talksDir = join(contentDir, 'talks')
 const blogFiles = readdirSync(contentDir).filter(f => f.endsWith('.md'))
 const posts = blogFiles.map((f) => {
   const raw = readFileSync(join(contentDir, f), 'utf-8')
-  const { data } = matter(raw)
+  const { data, content } = matter(raw)
   const id = f.replace(/\.md$/, '')
   return {
     id,
@@ -21,6 +21,7 @@ const posts = blogFiles.map((f) => {
     date: data.date ?? new Date().toISOString().split('T')[0],
     type: 'blog',
     tags: null,
+    content,
   }
 })
 
@@ -30,7 +31,7 @@ if (existsSync(talksDir)) {
   const talkFiles = readdirSync(talksDir).filter(f => f.endsWith('.md'))
   for (const f of talkFiles) {
     const raw = readFileSync(join(talksDir, f), 'utf-8')
-    const { data } = matter(raw)
+    const { data, content } = matter(raw)
     const id = f.replace(/\.md$/, '')
     talks.push({
       id,
@@ -40,6 +41,7 @@ if (existsSync(talksDir)) {
       date: data.date ?? new Date().toISOString().split('T')[0],
       type: 'talk',
       tags: null,
+      content,
     })
   }
 }
@@ -48,11 +50,11 @@ if (existsSync(talksDir)) {
 const esc = (s) => (s ?? '').replace(/'/g, "''")
 
 const blogInserts = posts.map((p) => {
-  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags) VALUES ('${esc(p.id)}', '${esc(p.title)}', '${esc(p.description)}', '${esc(p.category)}', '${esc(p.date)}', 'blog', NULL);`
+  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags, content) VALUES ('${esc(p.id)}', '${esc(p.title)}', '${esc(p.description)}', '${esc(p.category)}', '${esc(p.date)}', 'blog', NULL, '${esc(p.content)}');`
 })
 
 const talkInserts = talks.map((t) => {
-  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags) VALUES ('${esc(t.id)}', '${esc(t.title)}', '${esc(t.description)}', '${esc(t.category)}', '${esc(t.date)}', 'talk', NULL);`
+  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags, content) VALUES ('${esc(t.id)}', '${esc(t.title)}', '${esc(t.description)}', '${esc(t.category)}', '${esc(t.date)}', 'talk', NULL, '${esc(t.content)}');`
 })
 
 console.log([...blogInserts, ...talkInserts].join('\n'))

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -50,16 +50,111 @@ export function Nav() {
         <a href="/speaking">speaking</a>
         <a href="/projects">projects</a>
         <a href="/about">about</a>
+        <button class="search-toggle" onclick="openSearch()" title="Search (Cmd+K)" aria-label="Open search">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+        </button>
         <button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark mode">
           <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
           <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
         </button>
       </nav>
     </header>
+
+    <div id="search-overlay" class="search-overlay" onclick="closeSearch(event)">
+      <div class="search-panel" onclick="event.stopPropagation()">
+        <div class="search-input-wrap">
+          <svg class="search-input-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+          <input id="search-input" type="search" class="search-input" placeholder="Search posts and talks..." autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+          <kbd class="search-hint">ESC</kbd>
+        </div>
+        <div id="search-results" class="search-results"></div>
+      </div>
+    </div>
+
     <script>
+      var searchTimeout;
+      var searchOverlay = document.getElementById('search-overlay');
+      var searchInput = document.getElementById('search-input');
+      var searchResults = document.getElementById('search-results');
+
+      function openSearch() {
+        searchOverlay.classList.add('open');
+        setTimeout(function() { searchInput.focus(); }, 100);
+        document.body.style.overflow = 'hidden';
+      }
+
+      function closeSearch(e) {
+        if (e && e.target !== e.currentTarget) return;
+        searchOverlay.classList.remove('open');
+        document.body.style.overflow = '';
+        searchInput.value = '';
+        searchResults.innerHTML = '';
+        clearTimeout(searchTimeout);
+      }
+
+      searchInput.addEventListener('input', function() {
+        clearTimeout(searchTimeout);
+        var q = searchInput.value.trim();
+        if (q.length === 0) {
+          searchResults.innerHTML = '';
+          return;
+        }
+        searchTimeout = setTimeout(function() {
+          fetch('/api/search?q=' + encodeURIComponent(q))
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+              if (!data.results || data.results.length === 0) {
+                searchResults.innerHTML = '<div class="search-empty">No results found</div>';
+                return;
+              }
+              searchResults.innerHTML = data.results.map(function(r) {
+                var link = '/' + (r.type === 'blog' ? 'writing' : 'speaking') + '/' + r.id;
+                return '<a href="' + link + '" class="search-result" onclick="closeSearch()">' +
+                  '<span class="search-result-title">' + escapeHtml(r.title) + '</span>' +
+                  '<span class="search-result-meta">' +
+                    '<span class="tag">#' + escapeHtml(r.category) + '</span>' +
+                    (r.date ? ' ' + r.date : '') +
+                    (r.type === 'talk' ? ' <span class="tag tag-type">talk</span>' : '') +
+                  '</span>' +
+                  '</a>';
+              }).join('');
+            })
+            .catch(function() {
+              searchResults.innerHTML = '<div class="search-empty">Something went wrong</div>';
+            });
+        }, 200);
+      });
+
+      searchInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+          closeSearch({ target: searchOverlay, currentTarget: searchOverlay });
+        }
+        if (e.key === 'Enter') {
+          var firstResult = searchResults.querySelector('.search-result');
+          if (firstResult) firstResult.click();
+        }
+      });
+
+      document.addEventListener('keydown', function(e) {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+          e.preventDefault();
+          if (searchOverlay.classList.contains('open')) {
+            closeSearch({ target: searchOverlay, currentTarget: searchOverlay });
+          } else {
+            openSearch();
+          }
+        }
+      });
+
+      function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+      }
+
       function toggleTheme() {
-        const current = document.body.dataset.theme;
-        const next = current === 'dark' ? 'light' : 'dark';
+        var current = document.body.dataset.theme;
+        var next = current === 'dark' ? 'light' : 'dark';
         document.body.dataset.theme = next;
         localStorage.setItem('theme', next);
       }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -21,28 +21,35 @@ export function SearchPage({ query, results }: { query?: string; results?: Searc
           <div class="content">
             <div class="page-title">
               <h1>Search</h1>
+              <p>Search posts and talks across the site</p>
             </div>
-            <form action="/search" method="get" style="display:flex;gap:var(--space-sm);margin-bottom:var(--space-xl)">
+            <form action="/search" method="get" class="search-form">
               <input
                 type="search"
                 name="q"
                 value="${query ?? ''}"
                 placeholder="Search posts..."
-                style="flex:1;padding:var(--space-sm) var(--space-md);font-size:1rem;border:1px solid var(--color-text-muted);border-radius:var(--radius-md)"
+                class="search-form-input"
+                autofocus
               />
-              <button type="submit" style="padding:var(--space-sm) var(--space-md);background:var(--color-accent);color:white;border:none;border-radius:var(--radius-md);cursor:pointer">
+              <button type="submit" class="search-form-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
                 Search
               </button>
             </form>
             ${results && results.length > 0
               ? html`
+                <div class="search-results-count">
+                  ${results.length} result${results.length > 1 ? 's' : ''} for "${query}"
+                </div>
                 <div class="card-grid">
                   ${results.map((r) => html`
                     <article class="card">
                       <h3><a href="/${r.type === 'blog' ? 'writing' : 'speaking'}/${r.id}">${r.title}</a></h3>
                       <p>${r.description ?? ''}</p>
                       <div class="meta">
-                        <span class="tag">${r.category}</span>
+                        <span class="tag">#${r.category}</span>
+                        ${r.type === 'talk' ? html`<span class="tag tag-type">talk</span>` : ''}
                         ${r.date}
                       </div>
                     </article>
@@ -51,7 +58,12 @@ export function SearchPage({ query, results }: { query?: string; results?: Searc
               `
               : query
                 ? html`<p class="text-center text-muted">No results found for "${query}"</p>`
-                : ''
+                : html`
+                  <div class="search-empty-state">
+                    <p class="text-center text-muted">Start typing to search posts and talks.</p>
+                    <p class="text-center text-muted" style="font-size:0.85rem">Or press <kbd>Cmd+K</kbd> from anywhere on the site.</p>
+                  </div>
+                `
             }
           </div>
         </div>

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,8 +12,8 @@ app.get('/search', async (c) => {
   }
 
   const stmt = c.env.DB.prepare(
-    "SELECT id, title, description, category, date, type FROM posts WHERE title LIKE ? OR description LIKE ? ORDER BY date DESC LIMIT 20"
-  ).bind(`%${query}%`, `%${query}%`)
+    "SELECT id, title, description, category, date, type FROM posts WHERE title LIKE ? OR description LIKE ? OR content LIKE ? ORDER BY date DESC LIMIT 20"
+  ).bind(`%${query}%`, `%${query}%`, `%${query}%`)
 
   const { results } = await stmt.all<{
     id: string

--- a/src/routes/dynamic.ts
+++ b/src/routes/dynamic.ts
@@ -81,8 +81,8 @@ app.get('/search', async (c) => {
   }
 
   const stmt = c.env.DB.prepare(
-    "SELECT id, title, description, category, date, type FROM posts WHERE title LIKE ? OR description LIKE ? ORDER BY date DESC LIMIT 20"
-  ).bind(`%${query}%`, `%${query}%`)
+    "SELECT id, title, description, category, date, type FROM posts WHERE title LIKE ? OR description LIKE ? OR content LIKE ? ORDER BY date DESC LIMIT 20"
+  ).bind(`%${query}%`, `%${query}%`, `%${query}%`)
 
   const { results } = await stmt.all<{
     id: string

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -380,7 +380,9 @@ main.home-main {
 
 .page-title.home-hero h1 {
   color: var(--color-text);
-  font-size: 3rem;
+  font-size: clamp(1.5rem, 8vw, 3rem);
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .home-h1-monoton {
@@ -839,6 +841,183 @@ footer {
 
 .link-accent:hover {
   text-decoration: underline;
+}
+
+/* Search toggle in nav */
+.search-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-xs);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.9;
+  transition: opacity 0.2s;
+  border-radius: var(--radius-sm);
+}
+
+.search-toggle:hover {
+  opacity: 1;
+}
+
+/* === Search Overlay === */
+.search-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.search-overlay.open {
+  display: flex;
+}
+
+.search-panel {
+  background: var(--color-bg-card);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg), 0 0 0 1px var(--color-accent-light);
+  width: 100%;
+  max-width: 600px;
+  margin: 0 var(--space-md);
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--color-accent-light);
+}
+
+.search-input-icon {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+}
+
+.search-input {
+  flex: 1;
+  border: none;
+  background: none;
+  font-size: 1.1rem;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  outline: none;
+}
+
+.search-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.search-hint {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.2em 0.5em;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent-light);
+  color: var(--color-text-muted);
+}
+
+.search-results {
+  overflow-y: auto;
+  padding: var(--space-sm);
+}
+
+.search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  transition: background 0.15s;
+  text-decoration: none;
+}
+
+.search-result:hover {
+  background: var(--color-accent-light);
+  text-decoration: none;
+}
+
+.search-result-title {
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.search-result-meta {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.search-empty {
+  text-align: center;
+  padding: var(--space-xl);
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+/* === Search Form (Page) === */
+.search-form {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xl);
+}
+
+.search-form-input {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  font-size: 1rem;
+  font-family: var(--font-body);
+  border: 1px solid var(--color-text-muted);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-card);
+  color: var(--color-text);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.search-form-input:focus {
+  border-color: var(--color-accent);
+}
+
+.search-form-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.search-form-btn:hover {
+  opacity: 0.9;
+}
+
+.search-results-count {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-lg);
+}
+
+.search-empty-state {
+  padding: var(--space-2xl) 0;
 }
 
 /* === Utility === */

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -6,7 +6,7 @@ beforeAll(async () => {
     {
       name: '0001_initial_schema',
       queries: [
-        `create table if not exists posts (id text primary key, title text not null, description text, category text not null, date text not null, type text not null default 'blog', tags text)`,
+        `create table if not exists posts (id text primary key, title text not null, description text, category text not null, date text not null, type text not null default 'blog', tags text, content text)`,
       ],
     },
     {
@@ -25,6 +25,33 @@ describe('api routes', () => {
     const body = await res.json()
     expect(body).toEqual({ status: 'ok' })
   })
+
+  it('search returns empty results with no query', async () => {
+    const res = await SELF.fetch('http://localhost/api/search')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.results).toEqual([])
+  })
+
+  it('search returns results matching title or content', async () => {
+    await env.DB.prepare("INSERT INTO posts (id, title, description, category, date, type, content) VALUES ('test-post', 'Cloudflare Workers Guide', 'A guide to workers', 'dev', '2025-01-01', 'blog', 'This post covers Cloudflare Workers in depth')").run()
+    await env.DB.prepare("INSERT INTO posts (id, title, description, category, date, type, content) VALUES ('test-talk', 'My Talk', 'A talk about JS', 'general', '2025-02-01', 'talk', 'Nothing about workers here')").run()
+
+    const res = await SELF.fetch('http://localhost/api/search?q=workers')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.results.length).toBe(2)
+    const ids = body.results.map((r) => r.id)
+    expect(ids).toContain('test-post')
+    expect(ids).toContain('test-talk')
+  })
+
+  it('search returns no results for unknown term', async () => {
+    const res = await SELF.fetch('http://localhost/api/search?q=zzzznotfound')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.results).toEqual([])
+  })
 })
 
 describe('dynamic routes', () => {
@@ -34,6 +61,15 @@ describe('dynamic routes', () => {
     expect(res.headers.get('content-type')).toMatch(/text\/html/)
     const text = await res.text()
     expect(text).toContain('Search — kylieis.online')
+  })
+
+  it('search page with query returns results', async () => {
+    await env.DB.prepare("INSERT INTO posts (id, title, description, category, date, type, content) VALUES ('search-test', 'Test Post', 'A test post about search', 'dev', '2025-03-01', 'blog', 'This is the full content of the test post')").run()
+
+    const res = await SELF.fetch('http://localhost/search?q=search')
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('Test Post')
   })
 
   it('now page renders html', async () => {


### PR DESCRIPTION
## Search overlay
- 🔍 search icon in nav, accessible from every page
- `Cmd+K` / `Ctrl+K` keyboard shortcut
- live results via debounced fetch to `/api/search`
- ESC or click outside to close
- Enter to open first result

## Full content search
- store full post body in D1 `content` column
- search queries `title OR description OR content`
- terms like "workers" and "cloudflare" now match in post bodies

## Search page improvements
- styled form with focus states
- results count and empty state with Cmd+K hint

## Tests
- 4 new integration tests for search API and page (10 total)