### PR TITLE
feat: click to expand a pic

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -35,7 +35,9 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
         <script>
           document.body.dataset.theme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
         </script>
-        ${content}
+        <div class="page">
+          ${content}
+        </div>
       </body>
     </html>
   `

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -38,6 +38,87 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
         <div class="page">
           ${content}
         </div>
+        <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
+          <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+          <button class="photo-modal-nav photo-modal-prev" onclick="prevPhoto(event)" aria-label="Previous photo">
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+          </button>
+          <button class="photo-modal-nav photo-modal-next" onclick="nextPhoto(event)" aria-label="Next photo">
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+          </button>
+          <div class="photo-modal-content">
+            <img id="photo-modal-img" src="" alt="" />
+            <div class="photo-modal-caption">
+              <p id="photo-modal-alt"></p>
+              <p class="photo-modal-location" id="photo-modal-location"></p>
+            </div>
+          </div>
+        </div>
+        <script>
+          var photoModalPhotos = [];
+          var photoModalCurrentIndex = 0;
+
+          function openPhotoModal(index) {
+            photoModalCurrentIndex = index;
+            updatePhotoModal();
+            var modal = document.getElementById('photo-modal');
+            modal.classList.add('open');
+            document.body.style.overflow = 'hidden';
+          }
+          function openPhotoModalBySrc(src) {
+            for (var i = 0; i < photoModalPhotos.length; i++) {
+              if (photoModalPhotos[i].src === src) {
+                openPhotoModal(i);
+                return;
+              }
+            }
+            openPhotoModal(0);
+          }
+          function updatePhotoModal() {
+            var photo = photoModalPhotos[photoModalCurrentIndex];
+            if (!photo) return;
+            var img = document.getElementById('photo-modal-img');
+            var altEl = document.getElementById('photo-modal-alt');
+            var locationEl = document.getElementById('photo-modal-location');
+            img.src = photo.src;
+            img.alt = photo.alt;
+            altEl.textContent = photo.alt;
+            locationEl.textContent = photo.location;
+          }
+          function closePhotoModal() {
+            var modal = document.getElementById('photo-modal');
+            modal.classList.remove('open');
+            document.body.style.overflow = '';
+          }
+          function closePhotoModalOnBackdrop(event) {
+            if (event.target === event.currentTarget) {
+              closePhotoModal();
+            }
+          }
+          function prevPhoto(e) {
+            e.stopPropagation();
+            photoModalCurrentIndex = (photoModalCurrentIndex - 1 + photoModalPhotos.length) % photoModalPhotos.length;
+            updatePhotoModal();
+          }
+          function nextPhoto(e) {
+            e.stopPropagation();
+            photoModalCurrentIndex = (photoModalCurrentIndex + 1) % photoModalPhotos.length;
+            updatePhotoModal();
+          }
+          document.addEventListener('keydown', function(e) {
+            var modal = document.getElementById('photo-modal');
+            if (!modal.classList.contains('open')) return;
+            if (e.key === 'Escape') {
+              closePhotoModal();
+            } else if (e.key === 'ArrowLeft') {
+              prevPhoto(e);
+            } else if (e.key === 'ArrowRight') {
+              nextPhoto(e);
+            }
+          });
+        </script>
       </body>
     </html>
   `

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -35,6 +35,69 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
         <script>
           document.body.dataset.theme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
         </script>
+        <script>
+          if (!window.photoModalPhotos) window.photoModalPhotos = [];
+          var photoModalCurrentIndex = 0;
+
+          window.openPhotoModal = function(index) {
+            photoModalCurrentIndex = index;
+            window.updatePhotoModal();
+            var modal = document.getElementById('photo-modal');
+            modal.classList.add('open');
+            document.body.style.overflow = 'hidden';
+          };
+          window.openPhotoModalBySrc = function(src) {
+            for (var i = 0; i < window.photoModalPhotos.length; i++) {
+              if (window.photoModalPhotos[i].src === src) {
+                window.openPhotoModal(i);
+                return;
+              }
+            }
+            window.openPhotoModal(0);
+          };
+          window.updatePhotoModal = function() {
+            var photo = window.photoModalPhotos[photoModalCurrentIndex];
+            if (!photo) return;
+            var img = document.getElementById('photo-modal-img');
+            var altEl = document.getElementById('photo-modal-alt');
+            var locationEl = document.getElementById('photo-modal-location');
+            img.src = photo.src;
+            img.alt = photo.alt;
+            altEl.textContent = photo.alt;
+            locationEl.textContent = photo.location;
+          };
+          window.closePhotoModal = function() {
+            var modal = document.getElementById('photo-modal');
+            modal.classList.remove('open');
+            document.body.style.overflow = '';
+          };
+          window.closePhotoModalOnBackdrop = function(event) {
+            if (event.target === event.currentTarget) {
+              window.closePhotoModal();
+            }
+          };
+          window.prevPhoto = function(e) {
+            e.stopPropagation();
+            photoModalCurrentIndex = (photoModalCurrentIndex - 1 + window.photoModalPhotos.length) % window.photoModalPhotos.length;
+            window.updatePhotoModal();
+          };
+          window.nextPhoto = function(e) {
+            e.stopPropagation();
+            photoModalCurrentIndex = (photoModalCurrentIndex + 1) % window.photoModalPhotos.length;
+            window.updatePhotoModal();
+          };
+          document.addEventListener('keydown', function(e) {
+            var modal = document.getElementById('photo-modal');
+            if (!modal.classList.contains('open')) return;
+            if (e.key === 'Escape') {
+              window.closePhotoModal();
+            } else if (e.key === 'ArrowLeft') {
+              window.prevPhoto(e);
+            } else if (e.key === 'ArrowRight') {
+              window.nextPhoto(e);
+            }
+          });
+        </script>
         <div class="page">
           ${content}
         </div>
@@ -56,69 +119,6 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             </div>
           </div>
         </div>
-        <script>
-          if (!window.photoModalPhotos) window.photoModalPhotos = [];
-          var photoModalCurrentIndex = 0;
-
-          function openPhotoModal(index) {
-            photoModalCurrentIndex = index;
-            updatePhotoModal();
-            var modal = document.getElementById('photo-modal');
-            modal.classList.add('open');
-            document.body.style.overflow = 'hidden';
-          }
-          function openPhotoModalBySrc(src) {
-            for (var i = 0; i < window.photoModalPhotos.length; i++) {
-              if (window.photoModalPhotos[i].src === src) {
-                openPhotoModal(i);
-                return;
-              }
-            }
-            openPhotoModal(0);
-          }
-          function updatePhotoModal() {
-            var photo = window.photoModalPhotos[photoModalCurrentIndex];
-            if (!photo) return;
-            var img = document.getElementById('photo-modal-img');
-            var altEl = document.getElementById('photo-modal-alt');
-            var locationEl = document.getElementById('photo-modal-location');
-            img.src = photo.src;
-            img.alt = photo.alt;
-            altEl.textContent = photo.alt;
-            locationEl.textContent = photo.location;
-          }
-          function closePhotoModal() {
-            var modal = document.getElementById('photo-modal');
-            modal.classList.remove('open');
-            document.body.style.overflow = '';
-          }
-          function closePhotoModalOnBackdrop(event) {
-            if (event.target === event.currentTarget) {
-              closePhotoModal();
-            }
-          }
-          function prevPhoto(e) {
-            e.stopPropagation();
-            photoModalCurrentIndex = (photoModalCurrentIndex - 1 + window.photoModalPhotos.length) % window.photoModalPhotos.length;
-            updatePhotoModal();
-          }
-          function nextPhoto(e) {
-            e.stopPropagation();
-            photoModalCurrentIndex = (photoModalCurrentIndex + 1) % window.photoModalPhotos.length;
-            updatePhotoModal();
-          }
-          document.addEventListener('keydown', function(e) {
-            var modal = document.getElementById('photo-modal');
-            if (!modal.classList.contains('open')) return;
-            if (e.key === 'Escape') {
-              closePhotoModal();
-            } else if (e.key === 'ArrowLeft') {
-              prevPhoto(e);
-            } else if (e.key === 'ArrowRight') {
-              nextPhoto(e);
-            }
-          });
-        </script>
       </body>
     </html>
   `

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -37,24 +37,8 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
         </script>
         <script>
           if (!window.photoModalPhotos) window.photoModalPhotos = [];
-          var photoModalCurrentIndex = 0;
+          window.photoModalCurrentIndex = 0;
 
-          window.openPhotoModal = function(index) {
-            photoModalCurrentIndex = index;
-            window.updatePhotoModal();
-            var modal = document.getElementById('photo-modal');
-            modal.classList.add('open');
-            document.body.style.overflow = 'hidden';
-          };
-          window.openPhotoModalBySrc = function(src) {
-            for (var i = 0; i < window.photoModalPhotos.length; i++) {
-              if (window.photoModalPhotos[i].src === src) {
-                window.openPhotoModal(i);
-                return;
-              }
-            }
-            window.openPhotoModal(0);
-          };
           window.openPhotoModalFromEl = function(el) {
             var src = el.getAttribute('data-photo-src') || el.src;
             var alt = el.getAttribute('data-photo-alt') || el.alt;
@@ -85,16 +69,16 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             modal.classList.add('open');
             document.body.style.overflow = 'hidden';
             
-            photoModalCurrentIndex = 0;
+            window.photoModalCurrentIndex = 0;
             for (var i = 0; i < window.photoModalPhotos.length; i++) {
               if (window.photoModalPhotos[i].src === src) {
-                photoModalCurrentIndex = i;
+                window.photoModalCurrentIndex = i;
                 break;
               }
             }
           };
           window.updatePhotoModal = function() {
-            var photo = window.photoModalPhotos[photoModalCurrentIndex];
+            var photo = window.photoModalPhotos[window.photoModalCurrentIndex];
             if (!photo) return;
             var img = document.getElementById('photo-modal-img');
             var altEl = document.getElementById('photo-modal-alt');
@@ -117,13 +101,13 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
           window.prevPhoto = function(e) {
             if (e) e.stopPropagation();
             if (!window.photoModalPhotos || window.photoModalPhotos.length === 0) return;
-            photoModalCurrentIndex = (photoModalCurrentIndex - 1 + window.photoModalPhotos.length) % window.photoModalPhotos.length;
+            window.photoModalCurrentIndex = (window.photoModalCurrentIndex - 1 + window.photoModalPhotos.length) % window.photoModalPhotos.length;
             window.updatePhotoModal();
           };
           window.nextPhoto = function(e) {
             if (e) e.stopPropagation();
             if (!window.photoModalPhotos || window.photoModalPhotos.length === 0) return;
-            photoModalCurrentIndex = (photoModalCurrentIndex + 1) % window.photoModalPhotos.length;
+            window.photoModalCurrentIndex = (window.photoModalCurrentIndex + 1) % window.photoModalPhotos.length;
             window.updatePhotoModal();
           };
           document.addEventListener('keydown', function(e) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -38,50 +38,6 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
         <div class="page">
           ${content}
         </div>
-        <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
-          <div class="photo-modal-content">
-            <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-            </button>
-            <img id="photo-modal-img" src="" alt="" />
-            <div class="photo-modal-caption">
-              <p id="photo-modal-alt"></p>
-              <p class="photo-modal-location" id="photo-modal-location"></p>
-            </div>
-          </div>
-        </div>
-        <script>
-          function openPhotoModal(src, alt, location) {
-            const modal = document.getElementById('photo-modal');
-            const img = document.getElementById('photo-modal-img');
-            const altEl = document.getElementById('photo-modal-alt');
-            const locationEl = document.getElementById('photo-modal-location');
-            img.src = src;
-            img.alt = alt;
-            altEl.textContent = alt;
-            locationEl.textContent = location;
-            modal.classList.add('open');
-            document.body.style.overflow = 'hidden';
-          }
-          function closePhotoModal() {
-            const modal = document.getElementById('photo-modal');
-            modal.classList.remove('open');
-            document.body.style.overflow = '';
-          }
-          function closePhotoModalOnBackdrop(event) {
-            if (event.target === event.currentTarget) {
-              closePhotoModal();
-            }
-          }
-          document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape') {
-              const modal = document.getElementById('photo-modal');
-              if (modal.classList.contains('open')) {
-                closePhotoModal();
-              }
-            }
-          });
-        </script>
       </body>
     </html>
   `

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -60,6 +60,19 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             var alt = el.getAttribute('data-photo-alt') || el.alt;
             var location = el.getAttribute('data-photo-location') || '';
             
+            // Build photo array from all images with data-photo-src on the page
+            if (!window.photoModalPhotos || window.photoModalPhotos.length === 0) {
+              window.photoModalPhotos = [];
+              var photoEls = document.querySelectorAll('[data-photo-src]');
+              for (var j = 0; j < photoEls.length; j++) {
+                window.photoModalPhotos.push({
+                  src: photoEls[j].getAttribute('data-photo-src'),
+                  alt: photoEls[j].getAttribute('data-photo-alt') || photoEls[j].alt || '',
+                  location: photoEls[j].getAttribute('data-photo-location') || ''
+                });
+              }
+            }
+            
             var img = document.getElementById('photo-modal-img');
             var altEl = document.getElementById('photo-modal-alt');
             var locationEl = document.getElementById('photo-modal-location');
@@ -73,12 +86,10 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             document.body.style.overflow = 'hidden';
             
             photoModalCurrentIndex = 0;
-            if (window.photoModalPhotos && window.photoModalPhotos.length > 0) {
-              for (var i = 0; i < window.photoModalPhotos.length; i++) {
-                if (window.photoModalPhotos[i].src === src) {
-                  photoModalCurrentIndex = i;
-                  break;
-                }
+            for (var i = 0; i < window.photoModalPhotos.length; i++) {
+              if (window.photoModalPhotos[i].src === src) {
+                photoModalCurrentIndex = i;
+                break;
               }
             }
           };
@@ -104,23 +115,27 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             }
           };
           window.prevPhoto = function(e) {
-            e.stopPropagation();
+            if (e) e.stopPropagation();
+            if (!window.photoModalPhotos || window.photoModalPhotos.length === 0) return;
             photoModalCurrentIndex = (photoModalCurrentIndex - 1 + window.photoModalPhotos.length) % window.photoModalPhotos.length;
             window.updatePhotoModal();
           };
           window.nextPhoto = function(e) {
-            e.stopPropagation();
+            if (e) e.stopPropagation();
+            if (!window.photoModalPhotos || window.photoModalPhotos.length === 0) return;
             photoModalCurrentIndex = (photoModalCurrentIndex + 1) % window.photoModalPhotos.length;
             window.updatePhotoModal();
           };
           document.addEventListener('keydown', function(e) {
             var modal = document.getElementById('photo-modal');
-            if (!modal.classList.contains('open')) return;
+            if (!modal || !modal.classList.contains('open')) return;
             if (e.key === 'Escape') {
               window.closePhotoModal();
             } else if (e.key === 'ArrowLeft') {
+              e.preventDefault();
               window.prevPhoto(e);
             } else if (e.key === 'ArrowRight') {
+              e.preventDefault();
               window.nextPhoto(e);
             }
           });

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -38,6 +38,50 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
         <div class="page">
           ${content}
         </div>
+        <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
+          <div class="photo-modal-content">
+            <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+            </button>
+            <img id="photo-modal-img" src="" alt="" />
+            <div class="photo-modal-caption">
+              <p id="photo-modal-alt"></p>
+              <p class="photo-modal-location" id="photo-modal-location"></p>
+            </div>
+          </div>
+        </div>
+        <script>
+          function openPhotoModal(src, alt, location) {
+            const modal = document.getElementById('photo-modal');
+            const img = document.getElementById('photo-modal-img');
+            const altEl = document.getElementById('photo-modal-alt');
+            const locationEl = document.getElementById('photo-modal-location');
+            img.src = src;
+            img.alt = alt;
+            altEl.textContent = alt;
+            locationEl.textContent = location;
+            modal.classList.add('open');
+            document.body.style.overflow = 'hidden';
+          }
+          function closePhotoModal() {
+            const modal = document.getElementById('photo-modal');
+            modal.classList.remove('open');
+            document.body.style.overflow = '';
+          }
+          function closePhotoModalOnBackdrop(event) {
+            if (event.target === event.currentTarget) {
+              closePhotoModal();
+            }
+          }
+          document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+              const modal = document.getElementById('photo-modal');
+              if (modal.classList.contains('open')) {
+                closePhotoModal();
+              }
+            }
+          });
+        </script>
       </body>
     </html>
   `

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -72,15 +72,15 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             modal.classList.add('open');
             document.body.style.overflow = 'hidden';
             
-            if (window.photoModalPhotos.length > 1) {
+            photoModalCurrentIndex = 0;
+            if (window.photoModalPhotos && window.photoModalPhotos.length > 0) {
               for (var i = 0; i < window.photoModalPhotos.length; i++) {
                 if (window.photoModalPhotos[i].src === src) {
                   photoModalCurrentIndex = i;
-                  return;
+                  break;
                 }
               }
             }
-            photoModalCurrentIndex = 0;
           };
           window.updatePhotoModal = function() {
             var photo = window.photoModalPhotos[photoModalCurrentIndex];

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -55,6 +55,16 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             }
             window.openPhotoModal(0);
           };
+          window.openPhotoModalFromEl = function(el) {
+            var src = el.getAttribute('data-photo-src');
+            for (var i = 0; i < window.photoModalPhotos.length; i++) {
+              if (window.photoModalPhotos[i].src === src) {
+                window.openPhotoModal(i);
+                return;
+              }
+            }
+            window.openPhotoModal(0);
+          };
           window.updatePhotoModal = function() {
             var photo = window.photoModalPhotos[photoModalCurrentIndex];
             if (!photo) return;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -57,7 +57,7 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
           </div>
         </div>
         <script>
-          var photoModalPhotos = [];
+          if (!window.photoModalPhotos) window.photoModalPhotos = [];
           var photoModalCurrentIndex = 0;
 
           function openPhotoModal(index) {
@@ -68,8 +68,8 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             document.body.style.overflow = 'hidden';
           }
           function openPhotoModalBySrc(src) {
-            for (var i = 0; i < photoModalPhotos.length; i++) {
-              if (photoModalPhotos[i].src === src) {
+            for (var i = 0; i < window.photoModalPhotos.length; i++) {
+              if (window.photoModalPhotos[i].src === src) {
                 openPhotoModal(i);
                 return;
               }
@@ -77,7 +77,7 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             openPhotoModal(0);
           }
           function updatePhotoModal() {
-            var photo = photoModalPhotos[photoModalCurrentIndex];
+            var photo = window.photoModalPhotos[photoModalCurrentIndex];
             if (!photo) return;
             var img = document.getElementById('photo-modal-img');
             var altEl = document.getElementById('photo-modal-alt');
@@ -99,12 +99,12 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
           }
           function prevPhoto(e) {
             e.stopPropagation();
-            photoModalCurrentIndex = (photoModalCurrentIndex - 1 + photoModalPhotos.length) % photoModalPhotos.length;
+            photoModalCurrentIndex = (photoModalCurrentIndex - 1 + window.photoModalPhotos.length) % window.photoModalPhotos.length;
             updatePhotoModal();
           }
           function nextPhoto(e) {
             e.stopPropagation();
-            photoModalCurrentIndex = (photoModalCurrentIndex + 1) % photoModalPhotos.length;
+            photoModalCurrentIndex = (photoModalCurrentIndex + 1) % window.photoModalPhotos.length;
             updatePhotoModal();
           }
           document.addEventListener('keydown', function(e) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -56,14 +56,31 @@ export function Layout({ title, description, ogImage, content }: LayoutProps) {
             window.openPhotoModal(0);
           };
           window.openPhotoModalFromEl = function(el) {
-            var src = el.getAttribute('data-photo-src');
-            for (var i = 0; i < window.photoModalPhotos.length; i++) {
-              if (window.photoModalPhotos[i].src === src) {
-                window.openPhotoModal(i);
-                return;
+            var src = el.getAttribute('data-photo-src') || el.src;
+            var alt = el.getAttribute('data-photo-alt') || el.alt;
+            var location = el.getAttribute('data-photo-location') || '';
+            
+            var img = document.getElementById('photo-modal-img');
+            var altEl = document.getElementById('photo-modal-alt');
+            var locationEl = document.getElementById('photo-modal-location');
+            img.src = src;
+            img.alt = alt;
+            altEl.textContent = alt;
+            locationEl.textContent = location;
+            
+            var modal = document.getElementById('photo-modal');
+            modal.classList.add('open');
+            document.body.style.overflow = 'hidden';
+            
+            if (window.photoModalPhotos.length > 1) {
+              for (var i = 0; i < window.photoModalPhotos.length; i++) {
+                if (window.photoModalPhotos[i].src === src) {
+                  photoModalCurrentIndex = i;
+                  return;
+                }
               }
             }
-            window.openPhotoModal(0);
+            photoModalCurrentIndex = 0;
           };
           window.updatePhotoModal = function() {
             var photo = window.photoModalPhotos[photoModalCurrentIndex];

--- a/src/content.ts
+++ b/src/content.ts
@@ -93,7 +93,6 @@ export interface Photo {
 
 export const PHOTOS: Photo[] = [
   // San Francisco / Bay Area
-  { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/28d639b1-04bd-47ef-6445-07bd6618d400/public', alt: 'Golden Gate Bridge viewed from Fort Mason', location: 'Fort Mason, SF, CA' },
   { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/d2b975ee-c056-45ea-833b-069480c72300/public', alt: 'Golden Gate Bridge tower from the walkway', location: 'San Francisco, CA' },
   { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/4d95873b-909c-464e-0617-1cde69bd5000/public', alt: 'Sunset behind the Cliff House', location: 'Ocean Beach, SF, CA' },
   { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/20e6d214-7cbb-4434-efd8-bc8f6ddc5500/public', alt: 'Sunset over the Pacific at Baker Beach', location: 'Baker Beach, SF, CA' },
@@ -112,7 +111,6 @@ export const PHOTOS: Photo[] = [
   // Hawaii
   { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/aad40c68-a46b-4e2e-636a-7d1143197400/public', alt: 'HanakāpīʻAi Beach on the Napali Coast', location: 'Kauaʻi, HI' },
   { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/7bce8dfc-e822-4754-35aa-534b1210e800/public', alt: 'Aerial view of the Napali Coast', location: 'Kauaʻi, HI' },
-  { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/d86a79fe-92c4-4f76-e9a9-5be494c15a00/public', alt: 'Aerial view of the Napali Coast ridgeline', location: 'Kauaʻi, HI' },
   { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/a023ab45-f2d2-4bac-2265-bff003b13f00/public', alt: 'Sunrise from the Kailalau Trail', location: 'Kauaʻi, HI' },
   { src: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/e7b1bcd5-13b7-45b9-aad6-510345539a00/public', alt: 'The Napali Coast seen from sea', location: 'Kauaʻi, HI' },
   // Other

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -63,76 +63,11 @@ export function AboutPage() {
           </div>
         </div>
       </main>
-      <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
-        <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-        </button>
-        <button class="photo-modal-nav photo-modal-prev" onclick="prevPhoto(event)" aria-label="Previous photo">
-          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-        </button>
-        <button class="photo-modal-nav photo-modal-next" onclick="nextPhoto(event)" aria-label="Next photo">
-          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
-        </button>
-        <div class="photo-modal-content">
-          <img id="photo-modal-img" src="" alt="" />
-          <div class="photo-modal-caption">
-            <p id="photo-modal-alt"></p>
-            <p class="photo-modal-location" id="photo-modal-location"></p>
           </div>
         </div>
-      </div>
+      </main>
       <script>
-        var aboutPhotos = ${JSON.stringify(allPhotos)};
-        var currentPhotoIndex = 0;
-
-        function openPhotoModal(index) {
-          currentPhotoIndex = index;
-          updatePhotoModal();
-          const modal = document.getElementById('photo-modal');
-          modal.classList.add('open');
-          document.body.style.overflow = 'hidden';
-        }
-        function updatePhotoModal() {
-          const photo = aboutPhotos[currentPhotoIndex];
-          const img = document.getElementById('photo-modal-img');
-          const altEl = document.getElementById('photo-modal-alt');
-          const locationEl = document.getElementById('photo-modal-location');
-          img.src = photo.src;
-          img.alt = photo.alt;
-          altEl.textContent = photo.alt;
-          locationEl.textContent = photo.location;
-        }
-        function closePhotoModal() {
-          const modal = document.getElementById('photo-modal');
-          modal.classList.remove('open');
-          document.body.style.overflow = '';
-        }
-        function closePhotoModalOnBackdrop(event) {
-          if (event.target === event.currentTarget) {
-            closePhotoModal();
-          }
-        }
-        function prevPhoto(e) {
-          e.stopPropagation();
-          currentPhotoIndex = (currentPhotoIndex - 1 + aboutPhotos.length) % aboutPhotos.length;
-          updatePhotoModal();
-        }
-        function nextPhoto(e) {
-          e.stopPropagation();
-          currentPhotoIndex = (currentPhotoIndex + 1) % aboutPhotos.length;
-          updatePhotoModal();
-        }
-        document.addEventListener('keydown', function(e) {
-          const modal = document.getElementById('photo-modal');
-          if (!modal.classList.contains('open')) return;
-          if (e.key === 'Escape') {
-            closePhotoModal();
-          } else if (e.key === 'ArrowLeft') {
-            prevPhoto(e);
-          } else if (e.key === 'ArrowRight') {
-            nextPhoto(e);
-          }
-        });
+        photoModalPhotos = ${JSON.stringify(allPhotos)};
       </script>
       ${Footer()}
     `,

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -67,7 +67,7 @@ export function AboutPage() {
         </div>
       </main>
       <script>
-        photoModalPhotos = ${JSON.stringify(allPhotos)};
+        window.photoModalPhotos = ${JSON.stringify(allPhotos)};
       </script>
       ${Footer()}
     `,

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -24,7 +24,12 @@ function renderTimelineEntry(entry: TimelineEntry) {
 }
 
 export function AboutPage() {
-  const allPhotos: Photo[] = [...PERSONAL_TIMELINE.filter((e): e is typeof e & { image: string } => e.type === 'milestone').map((e) => ({ src: e.image, alt: e.title, location: e.location ?? '' })), ...PHOTOS]
+  const allPhotos: Photo[] = [
+    ...PERSONAL_TIMELINE
+      .filter((e): e is typeof e & { image: string } => e.type === 'milestone' && e.title !== 'First Conference Talk')
+      .map((e) => ({ src: e.image, alt: e.title, location: e.location ?? '' })),
+    ...PHOTOS
+  ]
 
   return Layout({
     title: 'About',

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -55,14 +55,11 @@ export function AboutPage() {
             <div class="photo-grid">
               ${allPhotos.map((photo, i) => html`
                 <div>
-                  <img src="${photo.src}" alt="${photo.alt}" loading="lazy" onclick="openPhotoModal(${i})" style="cursor: pointer;" />
+                  <img src="${photo.src}" alt="${photo.alt}" loading="lazy" onclick="openPhotoModalFromEl(this)" style="cursor: pointer;" data-photo-src="${photo.src}" data-photo-alt="${photo.alt}" data-photo-location="${photo.location}" />
                   <p class="photo-label">${photo.location}</p>
                 </div>
               `)}
             </div>
-          </div>
-        </div>
-      </main>
           </div>
         </div>
       </main>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,6 +1,6 @@
 import { html, raw } from 'hono/html'
 import { Layout, Nav, Footer } from '../components/Layout'
-import { METADATA, SOCIAL_LINKS, SOCIAL_ICONS, PERSONAL_TIMELINE, PHOTOS, TimelineEntry, Photo } from '../content'
+import { METADATA, SOCIAL_LINKS, SOCIAL_ICONS, PERSONAL_TIMELINE, PHOTOS, TimelineEntry, TimelineMilestone, Photo } from '../content'
 
 function renderTimelineEntry(entry: TimelineEntry) {
   if (entry.type === 'milestone') {
@@ -26,7 +26,7 @@ function renderTimelineEntry(entry: TimelineEntry) {
 export function AboutPage() {
   const allPhotos: Photo[] = [
     ...PERSONAL_TIMELINE
-      .filter((e): e is typeof e & { image: string } => e.type === 'milestone' && e.title !== 'First Conference Talk')
+      .filter((e): e is TimelineMilestone => e.type === 'milestone' && e.title !== 'First Conference Talk')
       .map((e) => ({ src: e.image, alt: e.title, location: e.location ?? '' })),
     ...PHOTOS
   ]

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,6 +1,6 @@
 import { html, raw } from 'hono/html'
 import { Layout, Nav, Footer } from '../components/Layout'
-import { METADATA, SOCIAL_LINKS, SOCIAL_ICONS, PERSONAL_TIMELINE, PHOTOS, TimelineEntry } from '../content'
+import { METADATA, SOCIAL_LINKS, SOCIAL_ICONS, PERSONAL_TIMELINE, PHOTOS, TimelineEntry, Photo } from '../content'
 
 function renderTimelineEntry(entry: TimelineEntry) {
   if (entry.type === 'milestone') {
@@ -24,6 +24,8 @@ function renderTimelineEntry(entry: TimelineEntry) {
 }
 
 export function AboutPage() {
+  const allPhotos: Photo[] = [...PERSONAL_TIMELINE.filter((e): e is typeof e & { image: string } => e.type === 'milestone').map((e) => ({ src: e.image, alt: e.title, location: e.location ?? '' })), ...PHOTOS]
+
   return Layout({
     title: 'About',
     description: `${METADATA.fullName} — Engineering Manager, public speaker, and mountaineer.`,
@@ -51,9 +53,9 @@ export function AboutPage() {
             <hr class="divider" />
             <h2 class="text-center">Photos</h2>
             <div class="photo-grid">
-              ${PHOTOS.map((photo) => html`
+              ${allPhotos.map((photo, i) => html`
                 <div>
-                  <img src="${photo.src}" alt="${photo.alt}" loading="lazy" />
+                  <img src="${photo.src}" alt="${photo.alt}" loading="lazy" onclick="openPhotoModal(${i})" style="cursor: pointer;" />
                   <p class="photo-label">${photo.location}</p>
                 </div>
               `)}
@@ -61,6 +63,77 @@ export function AboutPage() {
           </div>
         </div>
       </main>
+      <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
+        <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
+        <button class="photo-modal-nav photo-modal-prev" onclick="prevPhoto(event)" aria-label="Previous photo">
+          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        </button>
+        <button class="photo-modal-nav photo-modal-next" onclick="nextPhoto(event)" aria-label="Next photo">
+          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </button>
+        <div class="photo-modal-content">
+          <img id="photo-modal-img" src="" alt="" />
+          <div class="photo-modal-caption">
+            <p id="photo-modal-alt"></p>
+            <p class="photo-modal-location" id="photo-modal-location"></p>
+          </div>
+        </div>
+      </div>
+      <script>
+        var aboutPhotos = ${JSON.stringify(allPhotos)};
+        var currentPhotoIndex = 0;
+
+        function openPhotoModal(index) {
+          currentPhotoIndex = index;
+          updatePhotoModal();
+          const modal = document.getElementById('photo-modal');
+          modal.classList.add('open');
+          document.body.style.overflow = 'hidden';
+        }
+        function updatePhotoModal() {
+          const photo = aboutPhotos[currentPhotoIndex];
+          const img = document.getElementById('photo-modal-img');
+          const altEl = document.getElementById('photo-modal-alt');
+          const locationEl = document.getElementById('photo-modal-location');
+          img.src = photo.src;
+          img.alt = photo.alt;
+          altEl.textContent = photo.alt;
+          locationEl.textContent = photo.location;
+        }
+        function closePhotoModal() {
+          const modal = document.getElementById('photo-modal');
+          modal.classList.remove('open');
+          document.body.style.overflow = '';
+        }
+        function closePhotoModalOnBackdrop(event) {
+          if (event.target === event.currentTarget) {
+            closePhotoModal();
+          }
+        }
+        function prevPhoto(e) {
+          e.stopPropagation();
+          currentPhotoIndex = (currentPhotoIndex - 1 + aboutPhotos.length) % aboutPhotos.length;
+          updatePhotoModal();
+        }
+        function nextPhoto(e) {
+          e.stopPropagation();
+          currentPhotoIndex = (currentPhotoIndex + 1) % aboutPhotos.length;
+          updatePhotoModal();
+        }
+        document.addEventListener('keydown', function(e) {
+          const modal = document.getElementById('photo-modal');
+          if (!modal.classList.contains('open')) return;
+          if (e.key === 'Escape') {
+            closePhotoModal();
+          } else if (e.key === 'ArrowLeft') {
+            prevPhoto(e);
+          } else if (e.key === 'ArrowRight') {
+            nextPhoto(e);
+          }
+        });
+      </script>
       ${Footer()}
     `,
   })

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -110,7 +110,7 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
         </div>
       </main>
       <script>
-        photoModalPhotos = ${JSON.stringify(items.filter((item): item is PhotoCard => item.type === 'photo').map((item) => ({ src: item.src, alt: item.alt, location: item.location })))};
+        window.photoModalPhotos = ${JSON.stringify(items.filter((item): item is PhotoCard => item.type === 'photo').map((item) => ({ src: item.src, alt: item.alt, location: item.location })))};
       </script>
       ${Footer()}
     `,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -89,8 +89,8 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
             ${items.map((item) => {
               if (item.type === 'photo') {
                 return html`
-                  <div class="card card-photo" onclick="openPhotoModalBySrc('${item.src}')" style="cursor: pointer;">
-                    <img src="${item.src}" alt="${item.alt}" />
+                  <div class="card card-photo" onclick="openPhotoModalFromEl(this.querySelector('img'))" style="cursor: pointer;">
+                    <img src="${item.src}" alt="${item.alt}" data-photo-src="${item.src}" data-photo-alt="${item.alt}" data-photo-location="${item.location}" />
                     <span class="photo-location">${item.location}</span>
                   </div>
                 `
@@ -111,7 +111,6 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
       </main>
       <script>
         window.photoModalPhotos = ${JSON.stringify(items.filter((item): item is PhotoCard => item.type === 'photo').map((item) => ({ src: item.src, alt: item.alt, location: item.location })))};
-        if (window.initPhotoModal) window.initPhotoModal();
       </script>
       ${Footer()}
     `,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -111,6 +111,7 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
       </main>
       <script>
         window.photoModalPhotos = ${JSON.stringify(items.filter((item): item is PhotoCard => item.type === 'photo').map((item) => ({ src: item.src, alt: item.alt, location: item.location })))};
+        if (window.initPhotoModal) window.initPhotoModal();
       </script>
       ${Footer()}
     `,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -110,10 +110,16 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
         </div>
       </main>
       <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
+        <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
+        <button class="photo-modal-nav photo-modal-prev" onclick="prevPhoto(event)" aria-label="Previous photo">
+          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        </button>
+        <button class="photo-modal-nav photo-modal-next" onclick="nextPhoto(event)" aria-label="Next photo">
+          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </button>
         <div class="photo-modal-content">
-          <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-          </button>
           <img id="photo-modal-img" src="" alt="" />
           <div class="photo-modal-caption">
             <p id="photo-modal-alt"></p>
@@ -122,17 +128,26 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
         </div>
       </div>
       <script>
+        var pagePhotos = ${JSON.stringify(items.filter((item): item is PhotoCard => item.type === 'photo').map((item) => ({ src: item.src, alt: item.alt, location: item.location })))};
+        var currentPhotoIndex = 0;
+
         function openPhotoModal(src, alt, location) {
+          currentPhotoIndex = pagePhotos.findIndex(function(p) { return p.src === src; });
+          if (currentPhotoIndex === -1) currentPhotoIndex = 0;
+          updatePhotoModal();
           const modal = document.getElementById('photo-modal');
+          modal.classList.add('open');
+          document.body.style.overflow = 'hidden';
+        }
+        function updatePhotoModal() {
+          const photo = pagePhotos[currentPhotoIndex];
           const img = document.getElementById('photo-modal-img');
           const altEl = document.getElementById('photo-modal-alt');
           const locationEl = document.getElementById('photo-modal-location');
-          img.src = src;
-          img.alt = alt;
-          altEl.textContent = alt;
-          locationEl.textContent = location;
-          modal.classList.add('open');
-          document.body.style.overflow = 'hidden';
+          img.src = photo.src;
+          img.alt = photo.alt;
+          altEl.textContent = photo.alt;
+          locationEl.textContent = photo.location;
         }
         function closePhotoModal() {
           const modal = document.getElementById('photo-modal');
@@ -144,12 +159,25 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
             closePhotoModal();
           }
         }
+        function prevPhoto(e) {
+          e.stopPropagation();
+          currentPhotoIndex = (currentPhotoIndex - 1 + pagePhotos.length) % pagePhotos.length;
+          updatePhotoModal();
+        }
+        function nextPhoto(e) {
+          e.stopPropagation();
+          currentPhotoIndex = (currentPhotoIndex + 1) % pagePhotos.length;
+          updatePhotoModal();
+        }
         document.addEventListener('keydown', function(e) {
+          const modal = document.getElementById('photo-modal');
+          if (!modal.classList.contains('open')) return;
           if (e.key === 'Escape') {
-            const modal = document.getElementById('photo-modal');
-            if (modal.classList.contains('open')) {
-              closePhotoModal();
-            }
+            closePhotoModal();
+          } else if (e.key === 'ArrowLeft') {
+            prevPhoto(e);
+          } else if (e.key === 'ArrowRight') {
+            nextPhoto(e);
           }
         });
       </script>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -87,15 +87,15 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
           </div>
           <div class="card-grid">
             ${items.map((item) => {
-      if (item.type === 'photo') {
-        return html`
-                  <div class="card card-photo">
+              if (item.type === 'photo') {
+                return html`
+                  <div class="card card-photo" onclick="openPhotoModal('${item.src}', '${item.alt.replace(/'/g, "\\'")}', '${item.location.replace(/'/g, "\\'")}')" style="cursor: pointer;">
                     <img src="${item.src}" alt="${item.alt}" />
                     <span class="photo-location">${item.location}</span>
                   </div>
                 `
-      }
-      return html`
+              }
+              return html`
                 <article class="card">
                   <h3><a href="${item.href}">${item.title}</a></h3>
                   <p>${item.description}</p>
@@ -105,10 +105,54 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
                   </div>
                 </article>
               `
-    })}
+            })}
           </div>
         </div>
       </main>
+      <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
+        <div class="photo-modal-content">
+          <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+          <img id="photo-modal-img" src="" alt="" />
+          <div class="photo-modal-caption">
+            <p id="photo-modal-alt"></p>
+            <p class="photo-modal-location" id="photo-modal-location"></p>
+          </div>
+        </div>
+      </div>
+      <script>
+        function openPhotoModal(src, alt, location) {
+          const modal = document.getElementById('photo-modal');
+          const img = document.getElementById('photo-modal-img');
+          const altEl = document.getElementById('photo-modal-alt');
+          const locationEl = document.getElementById('photo-modal-location');
+          img.src = src;
+          img.alt = alt;
+          altEl.textContent = alt;
+          locationEl.textContent = location;
+          modal.classList.add('open');
+          document.body.style.overflow = 'hidden';
+        }
+        function closePhotoModal() {
+          const modal = document.getElementById('photo-modal');
+          modal.classList.remove('open');
+          document.body.style.overflow = '';
+        }
+        function closePhotoModalOnBackdrop(event) {
+          if (event.target === event.currentTarget) {
+            closePhotoModal();
+          }
+        }
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape') {
+            const modal = document.getElementById('photo-modal');
+            if (modal.classList.contains('open')) {
+              closePhotoModal();
+            }
+          }
+        });
+      </script>
       ${Footer()}
     `,
   })

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -89,7 +89,7 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
             ${items.map((item) => {
               if (item.type === 'photo') {
                 return html`
-                  <div class="card card-photo" onclick="openPhotoModal('${item.src}', '${item.alt.replace(/'/g, "\\'")}', '${item.location.replace(/'/g, "\\'")}')" style="cursor: pointer;">
+                  <div class="card card-photo" onclick="openPhotoModalBySrc('${item.src}')" style="cursor: pointer;">
                     <img src="${item.src}" alt="${item.alt}" />
                     <span class="photo-location">${item.location}</span>
                   </div>
@@ -109,77 +109,8 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
           </div>
         </div>
       </main>
-      <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
-        <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-        </button>
-        <button class="photo-modal-nav photo-modal-prev" onclick="prevPhoto(event)" aria-label="Previous photo">
-          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-        </button>
-        <button class="photo-modal-nav photo-modal-next" onclick="nextPhoto(event)" aria-label="Next photo">
-          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
-        </button>
-        <div class="photo-modal-content">
-          <img id="photo-modal-img" src="" alt="" />
-          <div class="photo-modal-caption">
-            <p id="photo-modal-alt"></p>
-            <p class="photo-modal-location" id="photo-modal-location"></p>
-          </div>
-        </div>
-      </div>
       <script>
-        var pagePhotos = ${JSON.stringify(items.filter((item): item is PhotoCard => item.type === 'photo').map((item) => ({ src: item.src, alt: item.alt, location: item.location })))};
-        var currentPhotoIndex = 0;
-
-        function openPhotoModal(src, alt, location) {
-          currentPhotoIndex = pagePhotos.findIndex(function(p) { return p.src === src; });
-          if (currentPhotoIndex === -1) currentPhotoIndex = 0;
-          updatePhotoModal();
-          const modal = document.getElementById('photo-modal');
-          modal.classList.add('open');
-          document.body.style.overflow = 'hidden';
-        }
-        function updatePhotoModal() {
-          const photo = pagePhotos[currentPhotoIndex];
-          const img = document.getElementById('photo-modal-img');
-          const altEl = document.getElementById('photo-modal-alt');
-          const locationEl = document.getElementById('photo-modal-location');
-          img.src = photo.src;
-          img.alt = photo.alt;
-          altEl.textContent = photo.alt;
-          locationEl.textContent = photo.location;
-        }
-        function closePhotoModal() {
-          const modal = document.getElementById('photo-modal');
-          modal.classList.remove('open');
-          document.body.style.overflow = '';
-        }
-        function closePhotoModalOnBackdrop(event) {
-          if (event.target === event.currentTarget) {
-            closePhotoModal();
-          }
-        }
-        function prevPhoto(e) {
-          e.stopPropagation();
-          currentPhotoIndex = (currentPhotoIndex - 1 + pagePhotos.length) % pagePhotos.length;
-          updatePhotoModal();
-        }
-        function nextPhoto(e) {
-          e.stopPropagation();
-          currentPhotoIndex = (currentPhotoIndex + 1) % pagePhotos.length;
-          updatePhotoModal();
-        }
-        document.addEventListener('keydown', function(e) {
-          const modal = document.getElementById('photo-modal');
-          if (!modal.classList.contains('open')) return;
-          if (e.key === 'Escape') {
-            closePhotoModal();
-          } else if (e.key === 'ArrowLeft') {
-            prevPhoto(e);
-          } else if (e.key === 'ArrowRight') {
-            nextPhoto(e);
-          }
-        });
+        photoModalPhotos = ${JSON.stringify(items.filter((item): item is PhotoCard => item.type === 'photo').map((item) => ({ src: item.src, alt: item.alt, location: item.location })))};
       </script>
       ${Footer()}
     `,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -109,50 +109,6 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
           </div>
         </div>
       </main>
-      <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
-        <div class="photo-modal-content">
-          <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-          </button>
-          <img id="photo-modal-img" src="" alt="" />
-          <div class="photo-modal-caption">
-            <p id="photo-modal-alt"></p>
-            <p class="photo-modal-location" id="photo-modal-location"></p>
-          </div>
-        </div>
-      </div>
-      <script>
-        function openPhotoModal(src, alt, location) {
-          const modal = document.getElementById('photo-modal');
-          const img = document.getElementById('photo-modal-img');
-          const altEl = document.getElementById('photo-modal-alt');
-          const locationEl = document.getElementById('photo-modal-location');
-          img.src = src;
-          img.alt = alt;
-          altEl.textContent = alt;
-          locationEl.textContent = location;
-          modal.classList.add('open');
-          document.body.style.overflow = 'hidden';
-        }
-        function closePhotoModal() {
-          const modal = document.getElementById('photo-modal');
-          modal.classList.remove('open');
-          document.body.style.overflow = '';
-        }
-        function closePhotoModalOnBackdrop(event) {
-          if (event.target === event.currentTarget) {
-            closePhotoModal();
-          }
-        }
-        document.addEventListener('keydown', function(e) {
-          if (e.key === 'Escape') {
-            const modal = document.getElementById('photo-modal');
-            if (modal.classList.contains('open')) {
-              closePhotoModal();
-            }
-          }
-        });
-      </script>
       ${Footer()}
     `,
   })

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -109,6 +109,50 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
           </div>
         </div>
       </main>
+      <div id="photo-modal" class="photo-modal" onclick="closePhotoModalOnBackdrop(event)">
+        <div class="photo-modal-content">
+          <button class="photo-modal-close" onclick="closePhotoModal()" aria-label="Close photo modal" title="Close (ESC)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+          <img id="photo-modal-img" src="" alt="" />
+          <div class="photo-modal-caption">
+            <p id="photo-modal-alt"></p>
+            <p class="photo-modal-location" id="photo-modal-location"></p>
+          </div>
+        </div>
+      </div>
+      <script>
+        function openPhotoModal(src, alt, location) {
+          const modal = document.getElementById('photo-modal');
+          const img = document.getElementById('photo-modal-img');
+          const altEl = document.getElementById('photo-modal-alt');
+          const locationEl = document.getElementById('photo-modal-location');
+          img.src = src;
+          img.alt = alt;
+          altEl.textContent = alt;
+          locationEl.textContent = location;
+          modal.classList.add('open');
+          document.body.style.overflow = 'hidden';
+        }
+        function closePhotoModal() {
+          const modal = document.getElementById('photo-modal');
+          modal.classList.remove('open');
+          document.body.style.overflow = '';
+        }
+        function closePhotoModalOnBackdrop(event) {
+          if (event.target === event.currentTarget) {
+            closePhotoModal();
+          }
+        }
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape') {
+            const modal = document.getElementById('photo-modal');
+            if (modal.classList.contains('open')) {
+              closePhotoModal();
+            }
+          }
+        });
+      </script>
       ${Footer()}
     `,
   })

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -356,7 +356,7 @@ main.home-main {
 }
 
 /* Ensure footer stays at bottom and gradient is continuous */
-main.home-main + footer {
+main.home-main ~ footer {
   margin-top: auto;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -625,8 +625,11 @@ main.home-main + footer {
 .photo-modal {
   display: none;
   position: fixed;
-  inset: 0;
-  z-index: 9999;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10000;
   background: rgba(0, 0, 0, 0.95);
   align-items: center;
   justify-content: center;
@@ -655,21 +658,28 @@ main.home-main + footer {
 }
 
 .photo-modal-close {
-  position: absolute;
-  top: calc(-1 * var(--space-xl));
-  right: 0;
-  background: none;
-  border: none;
+  position: fixed;
+  top: var(--space-lg);
+  right: var(--space-lg);
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
   color: white;
   cursor: pointer;
   padding: var(--space-sm);
-  opacity: 0.8;
-  transition: opacity 0.2s;
-  z-index: 1;
+  opacity: 0.9;
+  transition: opacity 0.2s, background 0.2s;
+  z-index: 10001;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .photo-modal-close:hover {
   opacity: 1;
+  background: rgba(0, 0, 0, 0.7);
 }
 
 .photo-modal-caption {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -98,6 +98,8 @@ body {
   color: var(--color-text);
   background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-orange) 50%, var(--color-accent) 100%);
   background-size: 200% 200%;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -263,6 +265,7 @@ li code {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
 }
 
 .container {
@@ -341,12 +344,20 @@ main {
   background: var(--color-bg);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   padding: var(--space-2xl) var(--space-lg) var(--space-3xl);
+  min-height: 100vh;
 }
 
 /* Home page: no white background, gradient shows through */
 main.home-main {
   background: none;
   border-radius: 0;
+  min-height: auto;
+  margin-bottom: 0;
+}
+
+/* Ensure footer stays at bottom and gradient is continuous */
+main.home-main + footer {
+  margin-top: auto;
 }
 
 /* Home page card sizing */
@@ -608,6 +619,75 @@ main.home-main {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8), 0 0 8px rgba(0, 0, 0, 0.5);
   pointer-events: none;
   z-index: 1;
+}
+
+/* === Photo Modal === */
+.photo-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.95);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xl);
+}
+
+.photo-modal.open {
+  display: flex;
+}
+
+.photo-modal-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.photo-modal-content img {
+  max-width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+}
+
+.photo-modal-close {
+  position: absolute;
+  top: calc(-1 * var(--space-xl));
+  right: 0;
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  padding: var(--space-sm);
+  opacity: 0.8;
+  transition: opacity 0.2s;
+  z-index: 1;
+}
+
+.photo-modal-close:hover {
+  opacity: 1;
+}
+
+.photo-modal-caption {
+  margin-top: var(--space-lg);
+  text-align: center;
+  color: white;
+}
+
+.photo-modal-caption p {
+  margin: 0 0 var(--space-sm);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.photo-modal-location {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 /* === Footer === */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -642,7 +642,7 @@ main.home-main + footer {
 
 .photo-modal-content {
   position: relative;
-  max-width: 90vw;
+  max-width: 80vw;
   max-height: 90vh;
   display: flex;
   flex-direction: column;
@@ -651,10 +651,43 @@ main.home-main + footer {
 
 .photo-modal-content img {
   max-width: 100%;
-  max-height: 80vh;
+  max-height: 75vh;
   object-fit: contain;
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
+}
+
+.photo-modal-nav {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  color: white;
+  cursor: pointer;
+  padding: var(--space-sm);
+  opacity: 0.8;
+  transition: opacity 0.2s, background 0.2s;
+  z-index: 10001;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.photo-modal-nav:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.photo-modal-prev {
+  left: var(--space-lg);
+}
+
+.photo-modal-next {
+  right: var(--space-lg);
 }
 
 .photo-modal-close {


### PR DESCRIPTION
- added full-screen photo modal on home and /about pages with caption (alt text + location in monospace)
- arrow key navigation between photos in modal, ESC to close, backdrop click to close
- fixed scroll boundary to prevent scrolling out of main content area
- ensured continuous gradient background (no white background overflow)
- shared modal component in Layout to avoid duplicate code across pages