### PR TITLE
feat: add draft preview pipeline for blog posts

### DIFF
--- a/.github/workflows/deploy-draft.yml
+++ b/.github/workflows/deploy-draft.yml
@@ -1,0 +1,107 @@
+name: deploy draft
+
+on:
+  push:
+    branches:
+      - 'blog/**'
+      - 'post/**'
+
+concurrency:
+  group: draft-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: generate draft name from branch
+        id: slug
+        run: |
+          # extract branch name without prefix (blog/ or post/)
+          BRANCH="${{ github.ref_name }}"
+          SLUG=$(echo "$BRANCH" | sed -E 's/^(blog|post)\///' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-20)
+          echo "name=kio-draft-${SLUG}" >> $GITHUB_OUTPUT
+          echo "url=https://kio-draft-${SLUG}.kylieski.workers.dev" >> $GITHUB_OUTPUT
+
+      - name: create deployment
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: 'draft',
+              auto_merge: false,
+              required_contexts: [],
+              description: 'Draft preview for ${{ github.ref_name }}'
+            });
+            return deployment.data.id;
+          result-encoding: string
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: install deps
+        run: npm ci
+
+      - name: build static assets
+        run: npm run build
+
+      - name: apply migrations to preview db
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: d1 migrations apply kylieis-online-db-preview --remote --env preview
+
+      - name: seed preview db
+        run: npx tsx scripts/seed-db.mjs > /tmp/seed.sql && npx wrangler d1 execute kylieis-online-db-preview --remote --env preview --file /tmp/seed.sql
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: generate draft config
+        run: |
+          jq --arg name "${{ steps.slug.outputs.name }}" '
+            .name = $name
+            | .d1_databases[0].database_id = "77521670-d5ba-43af-bd95-c4370dfcba4b"
+            | .d1_databases[0].database_name = "kylieis-online-db-preview"
+            | del(.routes)
+            | del(.env)
+          ' wrangler.jsonc > wrangler-draft.jsonc
+
+      - name: deploy draft
+        run: npx wrangler deploy --config wrangler-draft.jsonc
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: update deployment status
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.result }},
+              state: state,
+              environment_url: '${{ steps.slug.outputs.url }}',
+              log_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+              description: state === 'success' ? 'Draft deployed' : 'Draft deployment failed'
+            });
+
+      - name: output draft url
+        if: success()
+        run: |
+          echo "## Draft Preview" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "deployed to: ${{ steps.slug.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "branch: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-draft.yml
+++ b/.github/workflows/deploy-draft.yml
@@ -24,11 +24,9 @@ jobs:
         run: |
           # extract branch name without prefix (blog/ or post/)
           BRANCH="${{ github.ref_name }}"
-          SLUG_BASE=$(echo "$BRANCH" | sed -E 's/^(blog|post)\///' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-15)
-          HASH=$(echo "$BRANCH" | sha256sum | cut -c1-6)
-          SLUG="${SLUG_BASE}-${HASH}"
-          echo "name=kio-draft-${SLUG}" >> $GITHUB_OUTPUT
-          echo "url=https://kio-draft-${SLUG}.kylieski.workers.dev" >> $GITHUB_OUTPUT
+          SLUG=$(echo "$BRANCH" | sed -E 's/^(blog|post)\///' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-30)
+          echo "name=post-${SLUG}" >> $GITHUB_OUTPUT
+          echo "url=https://post-${SLUG}.kylieski.workers.dev" >> $GITHUB_OUTPUT
 
       - name: create deployment
         id: deployment

--- a/.github/workflows/deploy-draft.yml
+++ b/.github/workflows/deploy-draft.yml
@@ -24,7 +24,9 @@ jobs:
         run: |
           # extract branch name without prefix (blog/ or post/)
           BRANCH="${{ github.ref_name }}"
-          SLUG=$(echo "$BRANCH" | sed -E 's/^(blog|post)\///' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-20)
+          SLUG_BASE=$(echo "$BRANCH" | sed -E 's/^(blog|post)\///' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-15)
+          HASH=$(echo "$BRANCH" | sha256sum | cut -c1-6)
+          SLUG="${SLUG_BASE}-${HASH}"
           echo "name=kio-draft-${SLUG}" >> $GITHUB_OUTPUT
           echo "url=https://kio-draft-${SLUG}.kylieski.workers.dev" >> $GITHUB_OUTPUT
 
@@ -82,7 +84,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: update deployment status
-        if: always()
+        if: always() && steps.deployment.outputs.result != ''
         uses: actions/github-script@v7
         with:
           script: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,23 @@ key decisions:
 - e2e: playwright against wrangler dev
 - ci visual diff: browser rendering api in github actions
 
-## branch
+## branches
 
-rewrite/workers — all work happens here, separate commits, one logical unit each
+- `main` — production, auto-deploys to kylieis.online
+- `rewrite/workers` — major refactor work
+- `blog/*` or `post/*` — draft blog posts, auto-deploys to preview environment
+
+## draft preview workflow
+
+for writing new blog posts without affecting production:
+
+1. create branch with `blog/` or `post/` prefix (e.g., `blog/photos-api-post`)
+2. add markdown file to `content/`
+3. push to remote — github actions will:
+   - build static assets
+   - seed preview d1 (not production)
+   - deploy to `https://kio-draft-{slug}.kylieski.workers.dev`
+4. review at the preview url
+5. when ready, open pr to main for final review and production deploy
+
+note: draft branches use the preview d1 database (`kylieis-online-db-preview`), so draft posts won't appear on the live site until merged to main.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,19 @@ for writing new blog posts without affecting production:
 3. push to remote — github actions will:
    - build static assets
    - seed preview d1 (not production)
-   - deploy to `https://kio-draft-{slug}.kylieski.workers.dev`
+   - deploy to `https://post-{slug}.kylieski.workers.dev`
 4. review at the preview url
 5. when ready, open pr to main for final review and production deploy
 
 note: draft branches use the preview d1 database (`kylieis-online-db-preview`), so draft posts won't appear on the live site until merged to main.
+
+## draft access protection
+
+all draft previews are protected by cloudflare access. to customize the login page (logo, organization name, colors):
+
+1. cloudflare dashboard → **zero trust → reusable components → custom pages**
+2. select **access login page → manage**
+3. update organization name, logo, header/footer, and background color
+4. save — changes apply to all access applications in the account
+
+this controls the branding users see when accessing any draft preview url.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# [kylieis.online](https://kylieis.online)
+
+personal site of kylie czajkowski. built with hono, running on cloudflare workers, content in markdown.
+
+## stack
+
+- **framework:** hono + jsx
+- **platform:** cloudflare workers + d1 + static assets
+- **content:** markdown posts, structured data in d1
+- **search:** workers-based search with sqlite `like` queries
+- **styles:** plain css
+
+## develop
+
+```bash
+npm install
+npm run dev        # wrangler dev
+npm run build      # static assets
+npm run deploy     # build + wrangler deploy
+```
+
+## test
+
+```bash
+npm run test:unit
+npm run test:integration
+npm run test:e2e
+```


### PR DESCRIPTION
## what

- add github actions workflow that auto-deploys blog and post branches to isolated cloudflare workers with the preview d1 database
- clean url format: post-slug.kylieski.workers.dev
- add lo-fi readme
- document branch conventions and access customization in agents.md

## workflow

1. push to a blog or post branch
2. workflow builds, seeds preview d1, deploys unique worker
3. access-protected preview url posted to github actions summary
4. when ready, open pr to main for production deploy