### PR TITLE
feat: photos-api integration, updated og-image generation

### DIFF
--- a/.github/workflows/deploy-draft.yml
+++ b/.github/workflows/deploy-draft.yml
@@ -66,6 +66,7 @@ jobs:
         run: npx tsx scripts/seed-db.mjs > /tmp/seed.sql && npx wrangler d1 execute kylieis-online-db-preview --remote --env preview --file /tmp/seed.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          DRAFT: 1
 
       - name: generate draft config
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,7 +27,7 @@ jobs:
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.sha,
+              ref: '${{ github.event.pull_request.head.sha }}',
               environment: 'preview',
               auto_merge: false,
               required_contexts: [],
@@ -41,7 +41,7 @@ jobs:
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           # extract first meaningful word: skip prefixes like fix:, feat:, chore:, etc.
-          WORD=$(echo "$TITLE" | sed -E 's/^(fix|feat|chore|docs|refactor|test|ci|style|perf|build|revert|rewrite|add|update|remove|delete)(\([^)]*\))?[:\!]?\s*//i' | awk '{print $1}' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]//g' | cut -c1-12)
+          WORD=$(echo "$TITLE" | sed -E 's/^(fix|feat|chore|docs|refactor|test|ci|style|perf|build|revert|rewrite|add|update|remove|delete)(\([^)]*\))?[:\!]?\s*//i' | awk '{print $1}' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g' | cut -c1-12)
           # fallback to pr number if empty
           [ -z "$WORD" ] && WORD="pr${{ github.event.pull_request.number }}"
           # add short pr number suffix for uniqueness
@@ -67,6 +67,7 @@ jobs:
         run: npx tsx scripts/seed-db.mjs > /tmp/seed.sql && npx wrangler d1 execute kylieis-online-db-preview --remote --env preview --file /tmp/seed.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          DRAFT: 1
 
       - name: generate preview config
         run: |

--- a/migrations/0004_add_draft_field.sql
+++ b/migrations/0004_add_draft_field.sql
@@ -1,0 +1,4 @@
+-- add draft field to posts for filtering production vs draft content
+alter table posts add column draft integer default 0;
+
+create index idx_posts_draft on posts(draft);

--- a/scripts/build-static.mjs
+++ b/scripts/build-static.mjs
@@ -11,6 +11,7 @@ import { NotFoundPage } from '../src/pages/NotFoundPage.js'
 import { ProjectsPage } from '../src/pages/ProjectsPage.js'
 import { PROJECTS } from '../src/content.js'
 import { generateOgImages } from './generate-og-images.mjs'
+import { getPhotos } from '../src/lib/photos-api.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
@@ -53,8 +54,13 @@ async function main() {
   copyDir(path.join(ROOT, 'styles'), path.join(OUT_DIR, 'styles'))
   console.log('  copied styles/ -> static/styles/')
 
+  // Fetch kylieis-online photos from photos-api (the curated personal photos)
+  console.log('  fetching kylieis-online photos from photos-api...')
+  const { photos: apiPhotos } = await getPhotos({ site: 'kylieis-online', limit: 50 })
+  console.log(`  fetched ${apiPhotos.length} photos`)
+
   // About
-  writeHtml('about/index.html', AboutPage())
+  writeHtml('about/index.html', AboutPage({ photos: apiPhotos }))
 
   // Read all content (blog posts + talks)
   const blogFiles = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.md'))

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -5,39 +5,123 @@ import { chromium } from 'playwright'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
-const OUT_DIR = path.join(ROOT, 'static', 'open-graph')
+const OUT_DIR = path.join(ROOT, 'static', 'og')
+
+// Embed Otis as base64 data URI so Playwright can render it
+const OTIS_BASE64 = fs.readFileSync(path.join(ROOT, 'public', 'images', 'otis.png')).toString('base64')
+const OTIS_DATA_URI = `data:image/png;base64,${OTIS_BASE64}`
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+const GRADIENTS = [
+  'linear-gradient(135deg, #e23500 0%, #ffbc2d 100%)',
+  'linear-gradient(135deg, #c41e00 0%, #ff9500 100%)',
+  'linear-gradient(135deg, #ff4e00 0%, #ffb700 100%)',
+  'linear-gradient(135deg, #ff6b35 0%, #ffbc2d 100%)',
+  'linear-gradient(135deg, #ff3b30 0%, #ff8c42 100%)',
+  'linear-gradient(135deg, #e23500 0%, #ff6b35 50%, #ffbc2d 100%)',
+  'linear-gradient(135deg, #c41e00 0%, #e23500 50%, #ff9500 100%)',
+  'linear-gradient(135deg, #ff4e00 0%, #ff8c42 50%, #ffb700 100%)',
+  'linear-gradient(135deg, #ff6b35 0%, #ffbc2d 50%, #ffd700 100%)',
+  'linear-gradient(135deg, #e23500 0%, #ff3b30 50%, #ff9500 100%)',
+  'linear-gradient(45deg, #ffbc2d 0%, #e23500 100%)',
+  'linear-gradient(45deg, #ffb700 0%, #c41e00 100%)',
+  'linear-gradient(45deg, #ff8c42 0%, #ff4e00 100%)',
+  'linear-gradient(45deg, #ff9500 0%, #e23500 50%, #c41e00 100%)',
+  'linear-gradient(90deg, #e23500 0%, #ffbc2d 100%)',
+  'linear-gradient(180deg, #ffbc2d 0%, #e23500 100%)',
+  'linear-gradient(225deg, #ff6b35 0%, #c41e00 100%)',
+  'linear-gradient(225deg, #ff9500 0%, #e23500 50%, #ff4e00 100%)',
+  'radial-gradient(circle at top left, #ffbc2d 0%, #e23500 100%)',
+  'radial-gradient(circle at bottom right, #e23500 0%, #ffbc2d 100%)',
+]
+
+const DISPLAY_FONTS = [
+  'Monoton',
+  'Rubik Glitch',
+  'Nabla',
+  'Silkscreen',
+  'Bitcount Prop Single',
+  'Megrim',
+  'Atomic Age',
+  'Jersey 10',
+]
+
+function getRandomGradient() {
+  return GRADIENTS[Math.floor(Math.random() * GRADIENTS.length)]
+}
+
+function getRandomFont() {
+  return DISPLAY_FONTS[Math.floor(Math.random() * DISPLAY_FONTS.length)]
+}
 
 const OG_TEMPLATE = `<!doctype html>
 <html lang="en">
 <head><meta charset="UTF-8" />
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500&family=Inter:wght@400;500&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Fira+Code:wght@400&family=Monoton&family=Rubik+Glitch&family=Nabla&family=Silkscreen&family=Bitcount+Prop+Single&family=Megrim&family=Atomic+Age&family=Jersey+10&display=swap');
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
     width: 1200px; height: 630px;
-    background: linear-gradient(135deg, #e23500 0%, #ffbc2d 100%);
+    background: GRADIENT;
     display: flex; flex-direction: column;
     justify-content: center; align-items: center;
     text-align: center; color: white;
-    font-family: 'Fraunces', serif; padding: 4rem;
+    font-family: 'Inter', sans-serif; padding: 2.5rem;
   }
-  h1 { font-size: 3.5rem; font-weight: 400; line-height: 1.2; max-width: 900px; margin-bottom: 1rem; }
-  p { font-family: 'Inter', sans-serif; font-size: 1.4rem; opacity: 0.9; max-width: 700px; }
-  .site { position: absolute; bottom: 2rem; font-family: 'Inter', sans-serif; font-size: 1rem; opacity: 0.7; letter-spacing: 0.05em; }
+  body.landing h1 { font-size: 7rem; max-width: 1150px; }
+  body.landing p { font-size: 2.5rem; max-width: 1050px; }
+  body.post h1 { font-size: 5.5rem; max-width: 1050px; }
+  body.post p { font-size: 2rem; max-width: 900px; }
+  h1 { font-family: 'FONT_FAMILY', sans-serif; font-weight: 400; line-height: 1.05; margin-bottom: 1.5rem; color: #fff; }
+  p { font-family: 'Inter', sans-serif; color: #fff; line-height: 1.4; }
+  .site { position: absolute; bottom: 1.5rem; left: 50%; transform: translateX(-50%); font-family: 'Fira Code', monospace; font-size: 1.6rem; opacity: 0.7; letter-spacing: 0.05em; }
+  .otis { position: absolute; bottom: 20px; right: 20px; width: 220px; height: auto; }
 </style></head>
-<body>
+<body class="PAGE_TYPE">
   <h1 id="t">TITLE</h1>
   <p id="d">DESCRIPTION</p>
   <div class="site">kylieis.online</div>
+  <img class="otis" src="OTIS_URI" alt="Otis" />
 </body></html>`
 
+const TAGLINES = [
+  'web developer public speaker',
+  'building on the edge',
+  'developing the agent development experience',
+  'mountaineer on the weekends',
+  'making things fast',
+  'working with Workers',
+  'shipping from the summit',
+  'peak bagger problem solver',
+  "building things that don't crash (usually)",
+  'chronic early adopter',
+  'agent of chaos',
+  'hiking the sierras',
+  'making the web weirder',
+  'trying to make the machines like me',
+  'edge case enthusiast',
+  'learning in public',
+]
+
+function getRandomTagline() {
+  return TAGLINES[Math.floor(Math.random() * TAGLINES.length)]
+}
+
 const OG_IMAGES = {
-  'home': { title: 'kylieis.online', description: 'Web developer and public speaker.' },
-  'writing': { title: 'Written Thoughts', description: 'Kylie is writing about Javascript, AI, and more.' },
-  'speaking': { title: 'Conference Talks & Presentations', description: 'Kylie is talking about Javascript, open source, GraphQL, and more.' },
-  'projects': { title: 'Projects', description: "A selection of Kylie's open source work." },
-  'about': { title: 'About', description: 'Kylie Czajkowski — Web developer and public speaker.' },
-  'now': { title: 'Now', description: "What Kylie is reading, watching, learning, and celebrating." },
+  'home': { title: 'kylieis.online', description: 'web developer public speaker' },
+  'writing': { title: 'Written Thoughts', description: 'kylie is writing about javascript ai and more' },
+  'speaking': { title: 'Conference Talks & Presentations', description: 'kylie is talking about javascript open source graphql and more' },
+  'projects': { title: 'Projects', description: 'a selection of kylies open source work' },
+  'about': { title: 'About', description: getRandomTagline() },
+  'now': { title: 'Now', description: 'what kylie is reading watching learning and celebrating' },
 }
 
 export async function generateOgImages(posts) {
@@ -53,7 +137,14 @@ export async function generateOgImages(posts) {
   const page = await browser.newPage({ viewport: { width: 1200, height: 630 } })
 
   for (const [name, { title, description }] of Object.entries(entries)) {
-    const html = OG_TEMPLATE.replace('TITLE', title).replace('DESCRIPTION', description)
+    const pageType = name.startsWith('post-') ? 'post' : 'landing'
+    const html = OG_TEMPLATE
+      .replace('GRADIENT', getRandomGradient())
+      .replace('FONT_FAMILY', getRandomFont())
+      .replace('PAGE_TYPE', pageType)
+      .replace('OTIS_URI', OTIS_DATA_URI)
+      .replace('TITLE', escapeHtml(title))
+      .replace('DESCRIPTION', escapeHtml(description))
     await page.setContent(html, { waitUntil: 'networkidle' })
     await page.screenshot({ path: path.join(OUT_DIR, `${name}.jpg`), type: 'jpeg', quality: 85 })
     console.log(`  og: ${name}.jpg`)

--- a/scripts/seed-db.mjs
+++ b/scripts/seed-db.mjs
@@ -50,14 +50,17 @@ if (existsSync(talksDir)) {
 // Generate SQL insert statements
 const esc = (s) => (s ?? '').replace(/'/g, "''")
 
+// DRAFT env var is set by draft/preview workflows to mark posts as draft
+const isDraft = process.env.DRAFT ? 1 : 0
+
 const blogInserts = posts.map((p) => {
-  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags, content) VALUES ('${esc(p.id)}', '${esc(p.title)}', '${esc(p.description)}', '${esc(p.category)}', '${esc(p.date)}', 'blog', NULL, '${esc(p.content)}');`
+  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags, content, draft) VALUES ('${esc(p.id)}', '${esc(p.title)}', '${esc(p.description)}', '${esc(p.category)}', '${esc(p.date)}', 'blog', NULL, '${esc(p.content)}', ${isDraft});`
 })
 
 const talkInserts = talks.map((t) => {
   const presentedAt = JSON.stringify(t.presentedAt)
-  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags, content, presented_at) VALUES ('${esc(t.id)}', '${esc(t.title)}', '${esc(t.description)}', '${esc(t.category)}', '${esc(t.date)}', 'talk', NULL, '${esc(t.content)}', '${esc(presentedAt)}');`
+  return `INSERT OR IGNORE INTO posts (id, title, description, category, date, type, tags, content, presented_at, draft) VALUES ('${esc(t.id)}', '${esc(t.title)}', '${esc(t.description)}', '${esc(t.category)}', '${esc(t.date)}', 'talk', NULL, '${esc(t.content)}', '${esc(presentedAt)}', ${isDraft});`
 })
 
 console.log([...blogInserts, ...talkInserts].join('\n'))
-console.error(`Generated ${blogInserts.length} blog posts and ${talkInserts.length} talks`)
+console.error(`Generated ${blogInserts.length} blog posts and ${talkInserts.length} talks (${isDraft ? 'draft' : 'production'} mode)`)

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,41 +1,64 @@
 import { html } from 'hono/html'
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 interface LayoutProps {
   title: string
   description?: string
   ogImage?: string
   canonicalUrl?: string
+  ogType?: string
   content: ReturnType<typeof html>
 }
 
-export function Layout({ title, description, ogImage, canonicalUrl, content }: LayoutProps) {
-  const ogImageUrl = ogImage ?? 'https://kylieis.online/open-graph/home.jpg'
+export function Layout({ title, description, ogImage, canonicalUrl, ogType, content }: LayoutProps) {
+  const ogImageUrl = ogImage ?? 'https://kylieis.online/og/home.jpg'
   const url = canonicalUrl ?? 'https://kylieis.online'
-  
+  const safeTitle = escapeHtml(title)
+  const safeDescription = escapeHtml(description ?? '')
+  const safeUrl = escapeHtml(url)
+  const safeOgImage = escapeHtml(ogImageUrl)
+  const pageType = ogType ?? 'website'
+
   return html`
     <!doctype html>
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-        <title>${title} — kylieis.online</title>
-        <meta name="description" content="${description ?? ''}" />
-        <link rel="canonical" href="${url}" />
-        <meta property="og:url" content="${url}" />
-        <meta property="og:title" content="${title} — kylieis.online" />
-        <meta property="og:description" content="${description ?? ''}" />
-        <meta property="og:image" content="${ogImageUrl}" />
+        <title>${safeTitle} — kylieis.online</title>
+        <meta name="description" content="${safeDescription}" />
+        <link rel="canonical" href="${safeUrl}" />
+        <link rel="icon" type="image/png" href="/favicon.png" />
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+        <meta name="theme-color" content="#e23500" />
+        <meta property="og:site_name" content="kylieis.online" />
+        <meta property="og:locale" content="en_US" />
+        <meta property="og:url" content="${safeUrl}" />
+        <meta property="og:title" content="${safeTitle} — kylieis.online" />
+        <meta property="og:description" content="${safeDescription}" />
+        <meta property="og:image" content="${safeOgImage}" />
+        <meta property="og:image:secure_url" content="${safeOgImage}" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta property="og:image:type" content="image/jpeg" />
-        <meta property="og:type" content="website" />
+        <meta property="og:image:alt" content="${safeTitle}" />
+        <meta property="og:type" content="${pageType}" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="${title} — kylieis.online" />
-        <meta name="twitter:description" content="${description ?? ''}" />
-        <meta name="twitter:image" content="${ogImageUrl}" />
+        <meta name="twitter:title" content="${safeTitle} — kylieis.online" />
+        <meta name="twitter:description" content="${safeDescription}" />
+        <meta name="twitter:image" content="${safeOgImage}" />
+        <meta name="twitter:image:alt" content="${safeTitle}" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Fraunces:opsz,wght@9..144,400;9..144,500&family=Monoton&family=Rubik+Glitch&family=Nabla&family=Silkscreen&family=Bitcount+Prop+Single&family=Megrim&family=Atomic+Age&family=Nanum+Gothic+Coding&family=Jersey+10&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Fraunces:opsz,wght@9..144,400;9..144,500&family=Fira+Code:wght@400;500&family=Monoton&family=Rubik+Glitch&family=Nabla&family=Silkscreen&family=Bitcount+Prop+Single&family=Megrim&family=Atomic+Age&family=Jersey+10&display=swap" rel="stylesheet" />
         <link rel="stylesheet" href="/styles/globals.css" />
       </head>
       <body>

--- a/src/content.ts
+++ b/src/content.ts
@@ -131,7 +131,7 @@ export const PHOTOS: Photo[] = [
 ]
 
 export const TAGLINES = [
-  'web developer and public speaker',
+  'web developer, public speaker',
   'building on the edge',
   'developing the agent development experience',
   'mountaineer on the weekends',

--- a/src/content.ts
+++ b/src/content.ts
@@ -56,6 +56,7 @@ export const METADATA = {
   fullName: 'Kylie Czajkowski',
   firstName: 'Kylie',
   siteName: 'kylieis.online',
+  profilePhoto: 'https://pbs.twimg.com/profile_images/2058684479225610241/5SP70J78_400x400.jpg',
 }
 
 export const PROJECTS: Project[] = [
@@ -87,9 +88,11 @@ export function getFeaturedProjects(): Project[] {
 
 export interface Photo {
   src: string
+  srcset?: string
   alt: string
   location: string
   date: string
+  blurhash?: string
 }
 
 export const PHOTOS: Photo[] = [
@@ -149,15 +152,17 @@ export const TAGLINES = [
 // Inline SVG icons for social links (no CDN dependency)
 export const SOCIAL_ICONS: Record<string, string> = {
   mail: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>',
-  bluesky: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"/></svg>',
+  bluesky: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="-1 -1 26 26" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"/></svg>',
   github: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>',
   instagram: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="20" x="2" y="2" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" x2="17.51" y1="6.5" y2="6.5"/></svg>',
   linkedin: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect width="4" height="12" x="2" y="9"/><circle cx="4" cy="4" r="2"/></svg>',
+  x: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l11.733 16h4.267l-11.733 -16z"/><path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772"/></svg>',
 }
 
 export const SOCIAL_LINKS = [
   { label: 'Email', url: 'mailto:hello@kylieis.online', icon: 'mail' },
   { label: 'Bluesky', url: 'https://bsky.app/profile/kylieis.online', icon: 'bluesky' },
+  { label: 'X', url: 'https://x.com/kyliestew', icon: 'x' },
   { label: 'Github', url: 'https://github.com/kale-stew', icon: 'github' },
   { label: 'Instagram', url: 'https://instagram.com/kalestewski', icon: 'instagram' },
   { label: 'LinkedIn', url: 'https://www.linkedin.com/in/kylieski/', icon: 'linkedin' },
@@ -201,7 +206,7 @@ export const PERSONAL_TIMELINE: TimelineEntry[] = [
     title: 'Moved to San Francisco',
     date: 'Jun 2024',
     location: 'San Francisco, CA',
-    image: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/e781d047-cb85-4ff1-c159-713d9d4ba300/public',
+    image: 'https://photos-api.kylieski.workers.dev/img/d1806c642ad6?w=800',
     photoDate: '2025-11',
   },
   // 2023
@@ -210,7 +215,7 @@ export const PERSONAL_TIMELINE: TimelineEntry[] = [
     title: 'Climbed Kilimanjaro',
     date: 'Sep 2023',
     location: 'Kilimanjaro National Park, Tanzania',
-    image: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/3377d417-525a-46a7-c097-5bd1d396ef00/public',
+    image: 'https://photos-api.kylieski.workers.dev/img/0a90a01f9022?w=800',
     photoDate: '2023-09',
   },
   {
@@ -266,8 +271,7 @@ export const PERSONAL_TIMELINE: TimelineEntry[] = [
     title: 'First Conference Talk',
     date: 'Apr 2018',
     location: 'San Francisco, CA',
-    // palace of the fine arts
-    image: 'https://imagedelivery.net/I5sMCdZloThK9NfMgVFKOw/1a8ad2d9-9f80-45ad-1ccb-ca8fbd1f4000/public'
+    image: 'https://photos-api.kylieski.workers.dev/img/3767021c0e7d?w=800',
   },
   {
     type: 'job',

--- a/src/lib/photos-api.ts
+++ b/src/lib/photos-api.ts
@@ -1,0 +1,93 @@
+/**
+ * photos-api client for kylieis.online
+ *
+ * Provides helpers for fetching photos and generating responsive image URLs
+ * from the photos-api worker (photos-api.kylieski.workers.dev)
+ */
+
+const PHOTOS_API_BASE = 'https://photos-api.kylieski.workers.dev'
+
+// Supported widths for responsive images
+export const IMAGE_WIDTHS = [200, 400, 800, 1600] as const
+export type ImageWidth = (typeof IMAGE_WIDTHS)[number]
+
+export interface Photo {
+  id: string
+  title: string | null
+  caption: string | null
+  location: string | null
+  date: string | null
+  width: number | null
+  height: number | null
+  blurhash: string | null
+  format: string
+  tags: string | null
+}
+
+export interface PhotosApiResponse {
+  photos: Photo[]
+  meta: {
+    limit: number
+    offset: number
+    count: number
+  }
+}
+
+/**
+ * Generate image URL for a photo
+ * @param photoId - The photo ID from photos-api
+ * @param width - Optional width (200, 400, 800, 1600) for resized WebP, or undefined for original
+ */
+export function getPhotoUrl(photoId: string, width?: ImageWidth): string {
+  const base = `${PHOTOS_API_BASE}/img/${photoId}`
+  return width ? `${base}?w=${width}` : base
+}
+
+/**
+ * Generate srcset attribute for responsive images
+ * @param photoId - The photo ID from photos-api
+ * @param widths - Array of widths to include (defaults to all)
+ */
+export function getPhotoSrcset(
+  photoId: string,
+  widths: readonly ImageWidth[] = IMAGE_WIDTHS
+): string {
+  return widths.map((w) => `${getPhotoUrl(photoId, w)} ${w}w`).join(', ')
+}
+
+/**
+ * Fetch a single photo by ID
+ */
+export async function getPhoto(photoId: string): Promise<Photo | null> {
+  try {
+    const res = await fetch(`${PHOTOS_API_BASE}/api/photos/${photoId}`)
+    if (!res.ok) return null
+    return res.json()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fetch photos with optional filtering
+ */
+export async function getPhotos(options?: {
+  site?: string
+  limit?: number
+  offset?: number
+}): Promise<PhotosApiResponse> {
+  const params = new URLSearchParams()
+  if (options?.site) params.set('site', options.site)
+  if (options?.limit) params.set('limit', String(options.limit))
+  if (options?.offset) params.set('offset', String(options.offset))
+
+  const url = `${PHOTOS_API_BASE}/api/photos${params.toString() ? `?${params}` : ''}`
+  const res = await fetch(url)
+
+  if (!res.ok) {
+    return { photos: [], meta: { limit: 0, offset: 0, count: 0 } }
+  }
+
+  return res.json()
+}
+

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,6 +1,7 @@
 import { html, raw } from 'hono/html'
 import { Layout, Nav, Footer } from '../components/Layout'
 import { METADATA, SOCIAL_LINKS, SOCIAL_ICONS, PERSONAL_TIMELINE, PHOTOS, TimelineEntry, TimelineMilestone, Photo } from '../content'
+import { getPhotoUrl, getPhotoSrcset, type Photo as ApiPhoto } from '../lib/photos-api'
 
 function renderTimelineEntry(entry: TimelineEntry) {
   if (entry.type === 'milestone') {
@@ -23,18 +24,30 @@ function renderTimelineEntry(entry: TimelineEntry) {
   `
 }
 
-export function AboutPage() {
-  const allPhotos: Photo[] = [
-    ...PERSONAL_TIMELINE
-      .filter((e): e is TimelineMilestone => e.type === 'milestone' && e.title !== 'First Conference Talk')
-      .map((e) => ({ src: e.image, alt: e.title, location: e.location ?? '', date: e.photoDate ?? e.date })),
-    ...PHOTOS
-  ].sort((a, b) => b.date.localeCompare(a.date))
+interface AboutPageProps {
+  photos?: ApiPhoto[]
+}
+
+export function AboutPage({ photos: apiPhotos }: AboutPageProps = {}) {
+  // Convert API photos to the Photo format used by the modal
+  const photosFromApi: Photo[] = (apiPhotos ?? []).map((p) => ({
+    src: getPhotoUrl(p.id, 800),
+    srcset: getPhotoSrcset(p.id),
+    alt: p.title ?? '',
+    location: p.location ?? '',
+    date: p.date ?? '',
+    blurhash: p.blurhash ?? undefined,
+  }))
+
+  // Use API photos for the photo grid (fallback to hardcoded PHOTOS if API fails)
+  // Timeline milestones have their own photos shown inline, so we don't duplicate them here
+  const allPhotos: Photo[] = (photosFromApi.length > 0 ? photosFromApi : PHOTOS)
+    .sort((a, b) => b.date.localeCompare(a.date))
 
   return Layout({
     title: 'About',
     description: `${METADATA.fullName} — Engineering Manager at Cloudflare, public speaker, and mountaineer who has climbed over 109 peaks above 14,000 feet.`,
-    ogImage: 'https://kylieis.online/open-graph/about.jpg',
+    ogImage: 'https://kylieis.online/og/about.jpg',
     canonicalUrl: 'https://kylieis.online/about',
     content: html`
       ${Nav()}
@@ -43,6 +56,9 @@ export function AboutPage() {
           <div class="content">
             <div class="page-title page-title--section">
               <h1>About</h1>
+            </div>
+            <div class="profile-photo">
+              <img src="${METADATA.profilePhoto}" alt="${METADATA.fullName}" />
             </div>
             <p class="text-center">
               ${METADATA.firstName} leads the Agent Experience team at Cloudflare, building the developer experience for AI agents on the Workers platform. Outside of work, she's a mountaineer who has climbed over 109 peaks above 4,267 meters (14,000 feet).
@@ -55,15 +71,28 @@ export function AboutPage() {
               `)}
             </div>
             <hr class="divider" />
-            <h2 class="text-center">Timeline</h2>
+            <h2 class="text-center">timeline</h2>
             ${PERSONAL_TIMELINE.map((entry) => renderTimelineEntry(entry))}
             <hr class="divider" />
-            <h2 class="text-center" id="photos">Photos</h2>
+            <h2 class="text-center" id="photos">photos</h2>
             <div class="photo-grid">
               ${allPhotos.map((photo) => html`
                 <div>
-                  <img src="${photo.src}" alt="${photo.alt}" loading="lazy" onclick="openPhotoModalFromEl(this)" style="cursor: pointer;" data-photo-src="${photo.src}" data-photo-alt="${photo.alt}" data-photo-location="${photo.location}" data-photo-date="${photo.date.split('-')[0]}" />
-                  <p class="photo-label">${photo.location} · ${photo.date.split('-')[0]}</p>
+                  <img 
+                    src="${photo.src}" 
+                    ${raw(photo.srcset ? `srcset="${photo.srcset}"` : '')}
+                    sizes="(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 400px"
+                    alt="${photo.alt}" 
+                    loading="lazy" 
+                    onclick="openPhotoModalFromEl(this)" 
+                    style="cursor: pointer;" 
+                    data-photo-src="${photo.src}" 
+                    data-photo-alt="${photo.alt}" 
+                    data-photo-location="${photo.location}" 
+                    data-photo-date="${photo.date.split('-')[0]}"
+                    ${raw(photo.blurhash ? `data-blurhash="${photo.blurhash}"` : '')}
+                  />
+                  <p class="photo-label">${photo.location}${photo.location && photo.date ? ' · ' : ''}${photo.date.split('-')[0]}</p>
                 </div>
               `)}
             </div>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -46,7 +46,7 @@ export function AboutPage({ photos: apiPhotos }: AboutPageProps = {}) {
 
   return Layout({
     title: 'About',
-    description: `${METADATA.fullName} — Engineering Manager at Cloudflare, public speaker, and mountaineer who has climbed over 109 peaks above 14,000 feet.`,
+    description: `${METADATA.fullName} — Engineering Manager at Cloudflare, public speaker, mountaineer who has climbed over 109 peaks above 14,000 feet.`,
     ogImage: 'https://kylieis.online/og/about.jpg',
     canonicalUrl: 'https://kylieis.online/about',
     content: html`
@@ -61,7 +61,7 @@ export function AboutPage({ photos: apiPhotos }: AboutPageProps = {}) {
               <img src="${METADATA.profilePhoto}" alt="${METADATA.fullName}" />
             </div>
             <p class="text-center">
-              ${METADATA.firstName} leads the Agent Experience team at Cloudflare, building the developer experience for AI agents on the Workers platform. Outside of work, she's a mountaineer who has climbed over 109 peaks above 4,267 meters (14,000 feet).
+              ${METADATA.firstName} leads the Agent Experience team at Cloudflare, building the developer experience for AI agents on the Workers platform. Outside of work, she's a mountaineer who has been above 4,267 meters (14,000 feet) more than 109 times.
             </p>
             <div class="social-icons">
               ${SOCIAL_LINKS.map((link) => html`

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -10,8 +10,9 @@ export function BlogPostPage({ post }: { post: BlogPost }) {
   return Layout({
     title: post.title,
     description: post.description ?? `A post about ${post.category} by Kylie Czajkowski.`,
-    ogImage: `https://kylieis.online/open-graph/post-${post.id}.jpg`,
+    ogImage: `https://kylieis.online/og/post-${post.id}.jpg`,
     canonicalUrl: `https://kylieis.online/writing/${post.id}`,
+    ogType: 'article',
     content: html`
       ${Nav()}
       <main>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
-import { html } from 'hono/html'
+import { html, raw } from 'hono/html'
 import { Layout, Nav, Footer } from '../components/Layout'
-import { PHOTOS, TAGLINES, PROJECTS } from '../content'
+import { PHOTOS, TAGLINES, PROJECTS, type Photo } from '../content'
+import { getPhotoUrl, getPhotoSrcset, type Photo as ApiPhoto } from '../lib/photos-api'
 
 interface HomePagePost {
   id: string
@@ -18,10 +19,27 @@ interface HomePageProject {
 }
 
 type ContentCard = { type: 'content'; title: string; href: string; description: string; date?: string; tag: string }
-type PhotoCard = { type: 'photo'; src: string; alt: string; location: string; date: string }
+type PhotoCard = { type: 'photo'; src: string; srcset?: string; alt: string; location: string; date: string; blurhash?: string }
 type CardItem = ContentCard | PhotoCard
 
-export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomePagePost[], featuredProjects: HomePageProject[] }) {
+interface HomePageProps {
+  recentPosts: HomePagePost[]
+  featuredProjects: HomePageProject[]
+  photos?: ApiPhoto[]
+}
+
+export function HomePage({ recentPosts, featuredProjects, photos: apiPhotos }: HomePageProps) {
+  // Convert API photos to the Photo format, or fall back to hardcoded PHOTOS
+  const photoSource: Photo[] = apiPhotos && apiPhotos.length > 0
+    ? apiPhotos.map((p) => ({
+        src: getPhotoUrl(p.id, 800),
+        srcset: getPhotoSrcset(p.id),
+        alt: p.title ?? '',
+        location: p.location ?? '',
+        date: p.date ?? '',
+        blurhash: p.blurhash ?? undefined,
+      }))
+    : PHOTOS
   const contentCards: ContentCard[] = [
     ...recentPosts.slice(0, 3).map((p) => ({
       type: 'content' as const,
@@ -52,7 +70,7 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
     contentCards.push(fallbackProjects.shift()!)
   }
 
-  const shuffled = [...PHOTOS].sort(() => Math.random() - 0.5)
+  const shuffled = [...photoSource].sort(() => Math.random() - 0.5)
   const totalContent = Math.min(contentCards.length, 4)
   const slots: ('content' | 'photo')[] = [
     'content', 'content', 'photo',
@@ -65,7 +83,15 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
       return contentCards[ci++]
     }
     const photo = shuffled[pi++ % shuffled.length]
-    return { type: 'photo', src: photo.src, alt: photo.alt, location: photo.location, date: photo.date }
+    return { 
+      type: 'photo', 
+      src: photo.src, 
+      srcset: photo.srcset,
+      alt: photo.alt, 
+      location: photo.location, 
+      date: photo.date,
+      blurhash: photo.blurhash,
+    }
   })
 
   const tagline = TAGLINES[Math.floor(Math.random() * TAGLINES.length)]
@@ -92,8 +118,18 @@ export function HomePage({ recentPosts, featuredProjects }: { recentPosts: HomeP
               if (item.type === 'photo') {
                 return html`
                   <div class="card card-photo" onclick="openPhotoModalFromEl(this.querySelector('img'))" style="cursor: pointer;">
-                    <img src="${item.src}" alt="${item.alt}" data-photo-src="${item.src}" data-photo-alt="${item.alt}" data-photo-location="${item.location}" data-photo-date="${item.date.split('-')[0]}" />
-                    <span class="photo-location">${item.location} · ${item.date.split('-')[0]}</span>
+                    <img 
+                      src="${item.src}" 
+                      ${raw(item.srcset ? `srcset="${item.srcset}"` : '')}
+                      sizes="(max-width: 600px) 100vw, 400px"
+                      alt="${item.alt}" 
+                      data-photo-src="${item.src}" 
+                      data-photo-alt="${item.alt}" 
+                      data-photo-location="${item.location}" 
+                      data-photo-date="${item.date.split('-')[0]}"
+                      ${raw(item.blurhash ? `data-blurhash="${item.blurhash}"` : '')}
+                    />
+                    <span class="photo-location">${item.location}${item.location && item.date ? ' · ' : ''}${item.date.split('-')[0]}</span>
                   </div>
                 `
               }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -95,12 +95,12 @@ export function HomePage({ recentPosts, featuredProjects, photos: apiPhotos }: H
   })
 
   const tagline = TAGLINES[Math.floor(Math.random() * TAGLINES.length)]
-  const fontClasses = ['home-h1-monoton', 'home-h1-glitch', 'home-h1-nabla', 'home-h1-silkscreen', 'home-h1-bitcount', 'home-h1-megrim', 'home-h1-atomic', 'home-h1-nanum', 'home-h1-jersey']
+  const fontClasses = ['home-h1-monoton', 'home-h1-glitch', 'home-h1-nabla', 'home-h1-silkscreen', 'home-h1-bitcount', 'home-h1-megrim', 'home-h1-atomic', 'home-h1-fira', 'home-h1-jersey']
   const h1FontClass = fontClasses[Math.floor(Math.random() * fontClasses.length)]
 
   return Layout({
-    title: 'Home',
-    description: 'Kylie Czajkowski — Engineering Manager at Cloudflare, public speaker, and mountaineer. Writing about JavaScript, AI, and building things.',
+    title: 'kylieis.online',
+    description: 'Kylie Czajkowski — Engineering Manager at Cloudflare, public speaker, mountaineer. Writing about JavaScript, AI, and building things.',
     canonicalUrl: 'https://kylieis.online/',
     content: html`
       ${Nav()}

--- a/src/pages/NowPage.tsx
+++ b/src/pages/NowPage.tsx
@@ -41,7 +41,7 @@ export function NowPage({ entry, allEntries }: { entry: NowEntry; allEntries: Pi
   return Layout({
     title: 'Now',
     description: "What Kylie is reading, watching, learning, and celebrating right now.",
-    ogImage: 'https://kylieis.online/open-graph/now.jpg',
+    ogImage: 'https://kylieis.online/og/now.jpg',
     canonicalUrl: 'https://kylieis.online/now',
     content: html`
       ${Nav()}

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -6,7 +6,7 @@ export function ProjectsPage({ projects }: { projects: Project[] }) {
   return Layout({
     title: 'Projects',
     description: 'A selection of open source work and side projects by Kylie Czajkowski.',
-    ogImage: 'https://kylieis.online/open-graph/projects.jpg',
+    ogImage: 'https://kylieis.online/og/projects.jpg',
     canonicalUrl: 'https://kylieis.online/projects',
     content: html`
       ${Nav()}

--- a/src/pages/SpeakingPage.tsx
+++ b/src/pages/SpeakingPage.tsx
@@ -18,7 +18,7 @@ export function SpeakingPage({ talks }: { talks: TalkListItem[] }) {
   return Layout({
     title: 'Speaking',
     description: 'Conference talks and presentations by Kylie Czajkowski on JavaScript, React, GraphQL, open source, and developer tools.',
-    ogImage: 'https://kylieis.online/open-graph/speaking.jpg',
+    ogImage: 'https://kylieis.online/og/speaking.jpg',
     canonicalUrl: 'https://kylieis.online/speaking',
     content: html`
       ${Nav()}

--- a/src/pages/TalkPage.tsx
+++ b/src/pages/TalkPage.tsx
@@ -27,8 +27,9 @@ export function TalkPage({ talk }: { talk: TalkPost }) {
   return Layout({
     title: talk.title,
     description: talk.description ?? `A talk by Kylie Czajkowski about ${talk.category}.`,
-    ogImage: `https://kylieis.online/open-graph/post-${talk.id}.jpg`,
+    ogImage: `https://kylieis.online/og/post-${talk.id}.jpg`,
     canonicalUrl: `https://kylieis.online/speaking/${talk.id}`,
+    ogType: 'article',
     content: html`
       ${Nav()}
       <main>

--- a/src/pages/WritingPage.tsx
+++ b/src/pages/WritingPage.tsx
@@ -10,7 +10,7 @@ export function WritingPage({ posts }: { posts: PostMeta[] }) {
   return Layout({
     title: 'Writing',
     description: 'Blog posts and articles by Kylie Czajkowski about JavaScript, AI, TypeScript, and building on the web.',
-    ogImage: 'https://kylieis.online/open-graph/writing.jpg',
+    ogImage: 'https://kylieis.online/og/writing.jpg',
     canonicalUrl: 'https://kylieis.online/writing',
     content: html`
       ${Nav()}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,7 +12,7 @@ app.get('/search', async (c) => {
   }
 
   const stmt = c.env.DB.prepare(
-    "SELECT id, title, description, category, date, type FROM posts WHERE title LIKE ? OR description LIKE ? OR content LIKE ? ORDER BY date DESC LIMIT 20"
+    "SELECT id, title, description, category, date, type FROM posts WHERE (draft = 0 OR draft IS NULL) AND (title LIKE ? OR description LIKE ? OR content LIKE ?) ORDER BY date DESC LIMIT 20"
   ).bind(`%${query}%`, `%${query}%`, `%${query}%`)
 
   const { results } = await stmt.all<{

--- a/src/routes/dynamic.ts
+++ b/src/routes/dynamic.ts
@@ -8,8 +8,11 @@ import { getFeaturedProjects } from '../content'
 const app = new Hono<{ Bindings: Env }>()
 
 app.get('/', async (c) => {
+  // Fetch posts from D1
+  // Note: Photos for homepage are currently hardcoded in content.ts
+  // Future: fetch random mix from photos-api
   const { results: posts } = await c.env.DB.prepare(
-    "SELECT id, title, description, category, date, type FROM posts ORDER BY date DESC LIMIT 3"
+    "SELECT id, title, description, category, date, type FROM posts WHERE draft = 0 OR draft IS NULL ORDER BY date DESC LIMIT 3"
   ).all<{
     id: string
     title: string
@@ -82,7 +85,7 @@ app.get('/search', async (c) => {
   }
 
   const stmt = c.env.DB.prepare(
-    "SELECT id, title, description, category, date, type FROM posts WHERE title LIKE ? OR description LIKE ? OR content LIKE ? ORDER BY date DESC LIMIT 20"
+    "SELECT id, title, description, category, date, type FROM posts WHERE (draft = 0 OR draft IS NULL) AND (title LIKE ? OR description LIKE ? OR content LIKE ?) ORDER BY date DESC LIMIT 20"
   ).bind(`%${query}%`, `%${query}%`, `%${query}%`)
 
   const { results } = await stmt.all<{

--- a/src/routes/og.tsx
+++ b/src/routes/og.tsx
@@ -1,12 +1,66 @@
 import { Hono } from 'hono'
-import { ImageResponse } from 'hono-og'
+import { ImageResponse, loadGoogleFont } from 'hono-og'
 import type { Env } from '../env'
+
+const GRADIENTS = [
+  'linear-gradient(135deg, #e23500 0%, #ffbc2d 100%)',
+  'linear-gradient(135deg, #c41e00 0%, #ff9500 100%)',
+  'linear-gradient(135deg, #ff4e00 0%, #ffb700 100%)',
+  'linear-gradient(135deg, #ff6b35 0%, #ffbc2d 100%)',
+  'linear-gradient(135deg, #ff3b30 0%, #ff8c42 100%)',
+  'linear-gradient(135deg, #e23500 0%, #ff6b35 50%, #ffbc2d 100%)',
+  'linear-gradient(135deg, #c41e00 0%, #e23500 50%, #ff9500 100%)',
+  'linear-gradient(135deg, #ff4e00 0%, #ff8c42 50%, #ffb700 100%)',
+  'linear-gradient(135deg, #ff6b35 0%, #ffbc2d 50%, #ffd700 100%)',
+  'linear-gradient(135deg, #e23500 0%, #ff3b30 50%, #ff9500 100%)',
+  'linear-gradient(45deg, #ffbc2d 0%, #e23500 100%)',
+  'linear-gradient(45deg, #ffb700 0%, #c41e00 100%)',
+  'linear-gradient(45deg, #ff8c42 0%, #ff4e00 100%)',
+  'linear-gradient(45deg, #ff9500 0%, #e23500 50%, #c41e00 100%)',
+  'linear-gradient(90deg, #e23500 0%, #ffbc2d 100%)',
+  'linear-gradient(180deg, #ffbc2d 0%, #e23500 100%)',
+  'linear-gradient(225deg, #ff6b35 0%, #c41e00 100%)',
+  'linear-gradient(225deg, #ff9500 0%, #e23500 50%, #ff4e00 100%)',
+  'radial-gradient(circle at top left, #ffbc2d 0%, #e23500 100%)',
+  'radial-gradient(circle at bottom right, #e23500 0%, #ffbc2d 100%)',
+]
+
+const DISPLAY_FONTS = [
+  'Monoton',
+  'Rubik Glitch',
+  'Nabla',
+  'Silkscreen',
+  'Bitcount Prop Single',
+  'Megrim',
+  'Atomic Age',
+  'Jersey 10',
+]
+
+function getRandomGradient() {
+  return GRADIENTS[Math.floor(Math.random() * GRADIENTS.length)]
+}
+
+function getRandomFont() {
+  return DISPLAY_FONTS[Math.floor(Math.random() * DISPLAY_FONTS.length)]
+}
 
 const app = new Hono<{ Bindings: Env }>()
 
 app.get('/', async (c) => {
   const title = c.req.query('title') || 'kylieis.online'
-  const subtitle = c.req.query('subtitle') || ''
+  const rawSubtitle = c.req.query('subtitle') || ''
+  const subtitle = rawSubtitle.toLowerCase().replace(/[.,;:!?'"\-–—]/g, '')
+  const isPost = c.req.query('type') === 'post' || title.length > 35
+  const fontFamily = getRandomFont()
+
+  const [displayFont, bodyFont, monoFont] = await Promise.all([
+    loadGoogleFont({ family: fontFamily, weight: 400 }),
+    loadGoogleFont({ family: 'Inter', weight: 400 }),
+    loadGoogleFont({ family: 'Fira Code', weight: 400 }),
+  ])
+
+  const titleSize = isPost ? (title.length > 50 ? '72px' : '88px') : (title.length > 20 ? '110px' : '140px')
+  const subtitleSize = isPost ? '32px' : '42px'
 
   return new ImageResponse(
     <div
@@ -17,8 +71,8 @@ app.get('/', async (c) => {
         justifyContent: 'center',
         width: '100%',
         height: '100%',
-        background: 'linear-gradient(135deg, #e23500 0%, #ffbc2d 100%)',
-        fontFamily: 'sans-serif',
+        background: getRandomGradient(),
+        fontFamily: 'Inter',
       }}
     >
       <div
@@ -27,17 +81,18 @@ app.get('/', async (c) => {
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '40px 60px',
+          padding: isPost ? '40px 60px' : '30px 40px',
         }}
       >
         <h1
           style={{
-            fontSize: title.length > 20 ? '64px' : '80px',
-            fontWeight: 'bold',
-            color: '#000',
-            margin: '0 0 16px 0',
+            fontFamily: fontFamily,
+            fontSize: titleSize,
+            fontWeight: 'normal',
+            color: '#fff',
+            margin: '0 0 24px 0',
             textAlign: 'center',
-            lineHeight: 1.1,
+            lineHeight: 1.05,
           }}
         >
           {title.toLowerCase()}
@@ -45,21 +100,22 @@ app.get('/', async (c) => {
         {subtitle && (
           <p
             style={{
-              fontSize: '32px',
+              fontFamily: 'Inter',
+              fontSize: subtitleSize,
               color: '#fff',
               margin: 0,
               textAlign: 'center',
-              fontStyle: 'italic',
+              lineHeight: 1.4,
             }}
           >
-            {subtitle.toLowerCase()}
+            {subtitle}
           </p>
         )}
       </div>
       <div
         style={{
           position: 'absolute',
-          bottom: '40px',
+          bottom: '28px',
           display: 'flex',
           alignItems: 'center',
           gap: '12px',
@@ -67,9 +123,10 @@ app.get('/', async (c) => {
       >
         <span
           style={{
-            fontSize: '28px',
+            fontFamily: 'Fira Code',
+            fontSize: '24px',
             color: '#fff',
-            fontWeight: 500,
+            opacity: 0.7,
           }}
         >
           kylieis.online
@@ -79,6 +136,26 @@ app.get('/', async (c) => {
     {
       width: 1200,
       height: 630,
+      fonts: [
+        {
+          name: fontFamily,
+          data: displayFont,
+          weight: 400,
+          style: 'normal',
+        },
+        {
+          name: 'Inter',
+          data: bodyFont,
+          weight: 400,
+          style: 'normal',
+        },
+        {
+          name: 'Fira Code',
+          data: monoFont,
+          weight: 400,
+          style: 'normal',
+        },
+      ],
     }
   )
 })

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1018,6 +1018,22 @@ footer {
   margin-bottom: var(--space-xs);
 }
 
+/* === Profile Photo === */
+.profile-photo {
+  display: flex;
+  justify-content: center;
+  margin-bottom: var(--space-xl);
+}
+
+.profile-photo img {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: var(--shadow-md);
+  border: 3px solid var(--color-bg-card);
+}
+
 /* === Social Icons === */
 .photo-grid {
   display: grid;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -474,8 +474,8 @@ main.home-main ~ footer {
   font-family: 'Atomic Age', sans-serif;
 }
 
-.home-h1-nanum {
-  font-family: 'Nanum Gothic Coding', monospace;
+.home-h1-fira {
+  font-family: 'Fira Code', monospace;
 }
 
 .home-h1-jersey {
@@ -1059,6 +1059,7 @@ footer {
   display: flex;
   justify-content: center;
   gap: var(--space-lg);
+  margin-top: var(--space-2xl);
   margin-bottom: var(--space-xl);
 }
 


### PR DESCRIPTION
### photos api

- adds src/lib/photos-api.ts client for fetching curated photos
- homepage and /about photo grids now use api photos with srcset + blurhash
- build pipeline fetches photos at build time with fallback to hardcoded set

### og images

- replaces single orange gradient with 20 brand-color variations (orange/red/yellow family)
- titles use random display fonts (monoton, rubik glitch, nabla, silkscreen, megrim, etc.)
- landing pages (/home, /about, etc.) get larger text; blog posts stay readable for long titles
- adds otis.png to every og image
- "kylieis.online" bottom label in fira code monospace, larger size
- descriptions are lowercase and stripped of punctuation
- home page og title is just "kylieis.online" instead of "Home — kylieis.online"

### meta + layout fixes

- html escaping on all layout meta tags
- adds favicon, apple-touch-icon, and theme-color meta
- og image paths updated from /open-graph/ to /og/
- social icons margin-top fix
- about page copy: removed extra "and", rephrased mountaineer bio
- site-wide monospace font switched from nanum gothic coding to fira code